### PR TITLE
[ci/cd] PR 제목 허용 스코프에 github 추가

### DIFF
--- a/.github/workflows/cowork-prod-ci.yml
+++ b/.github/workflows/cowork-prod-ci.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           script: |
             const title = context.payload.pull_request.title;
-            const allowedScopes = ['global', 'app', 'docs', 'ci/cd'];
+            const allowedScopes = ['global', 'app', 'docs', 'ci/cd', 'github'];
 
             const versionPattern = /^v\d{8}\.\d+$/;
             if (versionPattern.test(title)) {

--- a/.github/workflows/cowork-stage-ci.yml
+++ b/.github/workflows/cowork-stage-ci.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           script: |
             const title = context.payload.pull_request.title;
-            const allowedScopes = ['global', 'app', 'docs', 'ci/cd'];
+            const allowedScopes = ['global', 'app', 'docs', 'ci/cd', 'github'];
 
             const versionPattern = /^v\d{8}\.\d+$/;
             if (versionPattern.test(title)) {


### PR DESCRIPTION
## 개요

PR 제목 유효성 검사의 허용 스코프 목록에 `github`를 추가하였습니다.

## 본문

`cowork-stage-ci.yml`과 `cowork-prod-ci.yml`의 `validate-title` 단계에서 `allowedScopes`에 `github`가 누락되어 있었습니다. GitHub App 연동 관련 PR 제목에 `[github]` 스코프를 사용할 수 있도록 두 워크플로 모두에 추가하였습니다.