### PR TITLE
[github] issue 생성 시 중복 확인 및 라벨 자동 부착 추가

### DIFF
--- a/src/github/client/github-api.client.spec.ts
+++ b/src/github/client/github-api.client.spec.ts
@@ -9,7 +9,7 @@ import { CreateIssueDto } from '../dto/create-issue.dto';
 
 describe('GithubApiClient', () => {
   let client: GithubApiClient;
-  let httpService: { post: jest.Mock };
+  let httpService: { get: jest.Mock; post: jest.Mock };
 
   const dto: CreateIssueDto = {
     owner: 'my-org',
@@ -19,7 +19,7 @@ describe('GithubApiClient', () => {
   };
 
   beforeEach(async () => {
-    httpService = { post: jest.fn() };
+    httpService = { get: jest.fn(), post: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -110,6 +110,132 @@ describe('GithubApiClient', () => {
 
     const error = await client
       .createIssue('my-token', dto)
+      .catch((e: unknown) => e as AxiosError);
+
+    expect(error).toBeInstanceOf(AxiosError);
+    expect(error).not.toBeInstanceOf(GithubClientError);
+  });
+
+  it('open issue를 제목 기준으로 검색한다', async () => {
+    httpService.get.mockReturnValue(
+      of({
+        data: {
+          items: [
+            {
+              number: 7,
+              html_url: 'https://github.com/my-org/my-repo/issues/7',
+              title: 'Bug fix',
+            },
+          ],
+        },
+      }),
+    );
+
+    const result = await client.searchOpenIssuesByTitle('my-token', dto);
+
+    expect(result).toEqual([
+      {
+        number: 7,
+        html_url: 'https://github.com/my-org/my-repo/issues/7',
+        title: 'Bug fix',
+      },
+    ]);
+    expect(httpService.get).toHaveBeenCalledWith(
+      'https://api.github.com/search/issues',
+      expect.objectContaining({
+        params: {
+          q: 'repo:my-org/my-repo is:issue is:open in:title "Bug fix"',
+        },
+        headers: expect.objectContaining({
+          Authorization: 'Bearer my-token',
+        }) as unknown,
+      }),
+    );
+  });
+
+  it('기존 이슈에 라벨을 추가한다', async () => {
+    httpService.post.mockReturnValue(of({ data: {} }));
+
+    await client.addLabelsToIssue('my-token', dto, 7, ['bug']);
+
+    expect(httpService.post).toHaveBeenCalledWith(
+      'https://api.github.com/repos/my-org/my-repo/issues/7/labels',
+      { labels: ['bug'] },
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer my-token',
+        }) as unknown,
+      }),
+    );
+  });
+
+  it('repo 라벨 목록을 조회한다', async () => {
+    httpService.get.mockReturnValue(
+      of({
+        data: [{ name: 'bug' }, { name: 'enhancement:개선작업' }],
+      }),
+    );
+
+    const result = await client.listLabels('my-token', dto);
+
+    expect(result).toEqual(['bug', 'enhancement:개선작업']);
+    expect(httpService.get).toHaveBeenCalledWith(
+      'https://api.github.com/repos/my-org/my-repo/labels',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer my-token',
+        }) as unknown,
+      }),
+    );
+  });
+
+  it('repo에 라벨을 생성한다', async () => {
+    httpService.post.mockReturnValue(of({ data: {} }));
+
+    await client.createLabel('my-token', dto, {
+      name: 'bug:버그',
+      color: 'd73a4a',
+      description: '버그 또는 오작동',
+    });
+
+    expect(httpService.post).toHaveBeenCalledWith(
+      'https://api.github.com/repos/my-org/my-repo/labels',
+      {
+        name: 'bug:버그',
+        color: 'd73a4a',
+        description: '버그 또는 오작동',
+      },
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer my-token',
+        }) as unknown,
+      }),
+    );
+  });
+
+  it('검색 API의 4xx 응답은 GithubClientError로 변환한다', async () => {
+    const axiosError = new AxiosError('Validation Failed');
+    axiosError.response = {
+      data: { message: 'Validation Failed' },
+      status: 422,
+    } as unknown as AxiosResponse;
+    httpService.get.mockReturnValue(throwError(() => axiosError));
+
+    const error = await client
+      .searchOpenIssuesByTitle('my-token', dto)
+      .catch((e: unknown) => e as GithubClientError);
+
+    expect(error).toBeInstanceOf(GithubClientError);
+    expect(error.statusCode).toBe(422);
+  });
+
+  it('라벨 추가 API의 5xx 응답은 원본 에러를 던진다', async () => {
+    const axiosError = new AxiosError('Internal Server Error');
+    axiosError.response = { data: {}, status: 500 } as unknown as AxiosResponse;
+    httpService.post.mockReturnValue(throwError(() => axiosError));
+
+    const error = await client
+      .addLabelsToIssue('my-token', dto, 7, ['bug'])
       .catch((e: unknown) => e as AxiosError);
 
     expect(error).toBeInstanceOf(AxiosError);

--- a/src/github/client/github-api.client.ts
+++ b/src/github/client/github-api.client.ts
@@ -42,30 +42,12 @@ export class GithubApiClient {
             labels: dto.labels,
             assignees: dto.assignees,
           },
-          {
-            headers: {
-              ...GITHUB_HEADERS,
-              Authorization: `Bearer ${token}`,
-            },
-          },
+          { headers: this.authHeaders(token) },
         ),
       );
-
       return { number: data.number, html_url: data.html_url };
     } catch (error) {
-      if (
-        error instanceof AxiosError &&
-        error.response &&
-        error.response.status < 500
-      ) {
-        throw new GithubClientError(
-          (error.response.data as { message?: string })?.message ??
-            error.message,
-          error.response.status,
-        );
-      }
-
-      throw error;
+      this.handleGithubError(error);
     }
   }
 
@@ -81,14 +63,10 @@ export class GithubApiClient {
           `${GITHUB_API}/search/issues`,
           {
             params: { q: query },
-            headers: {
-              ...GITHUB_HEADERS,
-              Authorization: `Bearer ${token}`,
-            },
+            headers: this.authHeaders(token),
           },
         ),
       );
-
       return data.items.map((item) => ({
         number: item.number,
         html_url: item.html_url,
@@ -110,12 +88,7 @@ export class GithubApiClient {
         this.httpService.post(
           `${GITHUB_API}/repos/${dto.owner}/${dto.repo}/issues/${issueNumber}/labels`,
           { labels },
-          {
-            headers: {
-              ...GITHUB_HEADERS,
-              Authorization: `Bearer ${token}`,
-            },
-          },
+          { headers: this.authHeaders(token) },
         ),
       );
     } catch (error) {
@@ -128,15 +101,9 @@ export class GithubApiClient {
       const { data } = await firstValueFrom(
         this.httpService.get<GithubLabel[]>(
           `${GITHUB_API}/repos/${dto.owner}/${dto.repo}/labels`,
-          {
-            headers: {
-              ...GITHUB_HEADERS,
-              Authorization: `Bearer ${token}`,
-            },
-          },
+          { headers: this.authHeaders(token) },
         ),
       );
-
       return data.map((label) => label.name);
     } catch (error) {
       this.handleGithubError(error);
@@ -153,12 +120,7 @@ export class GithubApiClient {
         this.httpService.post(
           `${GITHUB_API}/repos/${dto.owner}/${dto.repo}/labels`,
           label,
-          {
-            headers: {
-              ...GITHUB_HEADERS,
-              Authorization: `Bearer ${token}`,
-            },
-          },
+          { headers: this.authHeaders(token) },
         ),
       );
     } catch (error) {
@@ -166,18 +128,22 @@ export class GithubApiClient {
     }
   }
 
+  private authHeaders(token: string) {
+    return { ...GITHUB_HEADERS, Authorization: `Bearer ${token}` };
+  }
+
   private handleGithubError(error: unknown): never {
     if (
       error instanceof AxiosError &&
       error.response &&
-      error.response.status < 500
+      error.response.status < 500 &&
+      error.response.status !== 429
     ) {
       throw new GithubClientError(
         (error.response.data as { message?: string })?.message ?? error.message,
         error.response.status,
       );
     }
-
     throw error;
   }
 }

--- a/src/github/client/github-api.client.ts
+++ b/src/github/client/github-api.client.ts
@@ -101,7 +101,7 @@ export class GithubApiClient {
       const { data } = await firstValueFrom(
         this.httpService.get<GithubLabel[]>(
           `${GITHUB_API}/repos/${dto.owner}/${dto.repo}/labels`,
-          { headers: this.authHeaders(token) },
+          { params: { per_page: 100 }, headers: this.authHeaders(token) },
         ),
       );
       return data.map((label) => label.name);

--- a/src/github/client/github-api.client.ts
+++ b/src/github/client/github-api.client.ts
@@ -11,6 +11,22 @@ export interface CreatedIssue {
   html_url: string;
 }
 
+export interface SearchedIssue {
+  number: number;
+  html_url: string;
+  title: string;
+}
+
+export interface GithubLabel {
+  name: string;
+}
+
+export interface CreateLabelPayload {
+  name: string;
+  color: string;
+  description?: string;
+}
+
 @Injectable()
 export class GithubApiClient {
   constructor(private readonly httpService: HttpService) {}
@@ -51,5 +67,116 @@ export class GithubApiClient {
 
       throw error;
     }
+  }
+
+  async searchOpenIssuesByTitle(
+    token: string,
+    dto: CreateIssueDto,
+  ): Promise<SearchedIssue[]> {
+    try {
+      const query = `repo:${dto.owner}/${dto.repo} is:issue is:open in:title "${dto.title}"`;
+      const { data } = await firstValueFrom(
+        this.httpService.get<{ items: SearchedIssue[] }>(
+          `${GITHUB_API}/search/issues`,
+          {
+            params: { q: query },
+            headers: {
+              ...GITHUB_HEADERS,
+              Authorization: `Bearer ${token}`,
+            },
+          },
+        ),
+      );
+
+      return data.items.map((item) => ({
+        number: item.number,
+        html_url: item.html_url,
+        title: item.title,
+      }));
+    } catch (error) {
+      this.handleGithubError(error);
+    }
+  }
+
+  async addLabelsToIssue(
+    token: string,
+    dto: CreateIssueDto,
+    issueNumber: number,
+    labels: string[],
+  ): Promise<void> {
+    try {
+      await firstValueFrom(
+        this.httpService.post(
+          `${GITHUB_API}/repos/${dto.owner}/${dto.repo}/issues/${issueNumber}/labels`,
+          { labels },
+          {
+            headers: {
+              ...GITHUB_HEADERS,
+              Authorization: `Bearer ${token}`,
+            },
+          },
+        ),
+      );
+    } catch (error) {
+      this.handleGithubError(error);
+    }
+  }
+
+  async listLabels(token: string, dto: CreateIssueDto): Promise<string[]> {
+    try {
+      const { data } = await firstValueFrom(
+        this.httpService.get<GithubLabel[]>(
+          `${GITHUB_API}/repos/${dto.owner}/${dto.repo}/labels`,
+          {
+            headers: {
+              ...GITHUB_HEADERS,
+              Authorization: `Bearer ${token}`,
+            },
+          },
+        ),
+      );
+
+      return data.map((label) => label.name);
+    } catch (error) {
+      this.handleGithubError(error);
+    }
+  }
+
+  async createLabel(
+    token: string,
+    dto: CreateIssueDto,
+    label: CreateLabelPayload,
+  ): Promise<void> {
+    try {
+      await firstValueFrom(
+        this.httpService.post(
+          `${GITHUB_API}/repos/${dto.owner}/${dto.repo}/labels`,
+          label,
+          {
+            headers: {
+              ...GITHUB_HEADERS,
+              Authorization: `Bearer ${token}`,
+            },
+          },
+        ),
+      );
+    } catch (error) {
+      this.handleGithubError(error);
+    }
+  }
+
+  private handleGithubError(error: unknown): never {
+    if (
+      error instanceof AxiosError &&
+      error.response &&
+      error.response.status < 500
+    ) {
+      throw new GithubClientError(
+        (error.response.data as { message?: string })?.message ?? error.message,
+        error.response.status,
+      );
+    }
+
+    throw error;
   }
 }

--- a/src/github/client/github-api.client.ts
+++ b/src/github/client/github-api.client.ts
@@ -74,7 +74,8 @@ export class GithubApiClient {
     dto: CreateIssueDto,
   ): Promise<SearchedIssue[]> {
     try {
-      const query = `repo:${dto.owner}/${dto.repo} is:issue is:open in:title "${dto.title}"`;
+      const escapedTitle = dto.title.replace(/"/g, '\\"');
+      const query = `repo:${dto.owner}/${dto.repo} is:issue is:open in:title "${escapedTitle}"`;
       const { data } = await firstValueFrom(
         this.httpService.get<{ items: SearchedIssue[] }>(
           `${GITHUB_API}/search/issues`,

--- a/src/github/github.module.ts
+++ b/src/github/github.module.ts
@@ -6,6 +6,7 @@ import { GithubAuthService } from './auth/github-auth.service';
 import { GithubApiClient } from './client/github-api.client';
 import { REDIS_CLIENT } from './constants';
 import { IssueService } from './issue/issue.service';
+import { LabelService } from './issue/label.service';
 import { GithubController } from './github.controller';
 
 @Module({
@@ -24,6 +25,7 @@ import { GithubController } from './github.controller';
     },
     GithubAuthService,
     GithubApiClient,
+    LabelService,
     IssueService,
   ],
   controllers: [GithubController],

--- a/src/github/issue/issue.service.spec.ts
+++ b/src/github/issue/issue.service.spec.ts
@@ -9,7 +9,13 @@ import { IssueService } from './issue.service';
 describe('IssueService', () => {
   let service: IssueService;
   let authService: { getInstallationToken: jest.Mock };
-  let apiClient: { createIssue: jest.Mock };
+  let apiClient: {
+    createIssue: jest.Mock;
+    searchOpenIssuesByTitle: jest.Mock;
+    addLabelsToIssue: jest.Mock;
+    listLabels: jest.Mock;
+    createLabel: jest.Mock;
+  };
 
   const dto: CreateIssueDto = {
     owner: 'team-cowork',
@@ -26,7 +32,21 @@ describe('IssueService', () => {
     authService = {
       getInstallationToken: jest.fn().mockResolvedValue('token'),
     };
-    apiClient = { createIssue: jest.fn() };
+    apiClient = {
+      createIssue: jest.fn(),
+      searchOpenIssuesByTitle: jest.fn().mockResolvedValue([]),
+      addLabelsToIssue: jest.fn().mockResolvedValue(undefined),
+      createLabel: jest.fn().mockResolvedValue(undefined),
+      listLabels: jest
+        .fn()
+        .mockResolvedValue([
+          'bug',
+          'bug:버그',
+          'enhancement:개선작업',
+          'help wanted:도움 필요',
+          'waiting for review:검토 대기',
+        ]),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -47,42 +67,197 @@ describe('IssueService', () => {
     await service.createIssue(dto);
 
     expect(authService.getInstallationToken).toHaveBeenCalledWith(dto.owner);
-    expect(apiClient.createIssue).toHaveBeenCalledWith('token', dto);
+    expect(apiClient.searchOpenIssuesByTitle).toHaveBeenCalledWith(
+      'token',
+      dto,
+    );
+    expect(apiClient.createIssue).toHaveBeenCalledWith('token', {
+      ...dto,
+      labels: ['help wanted:도움 필요'],
+    });
   });
 
-  it('일시적 오류 발생 시 성공할 때까지 재시도한다', async () => {
-    apiClient.createIssue
-      .mockRejectedValueOnce(new Error('temporary error'))
-      .mockRejectedValueOnce(new Error('temporary error'))
-      .mockResolvedValueOnce(createdIssue);
+  it('요청 labels가 없으면 repo 라벨 중 키워드 기반 라벨을 추론해 새 이슈에 붙인다', async () => {
+    apiClient.createIssue.mockResolvedValue(createdIssue);
+
+    await service.createIssue({
+      ...dto,
+      title: '로그인 500 에러',
+      body: '카카오 로그인 실패',
+    });
+
+    expect(apiClient.createIssue).toHaveBeenCalledWith(
+      'token',
+      expect.objectContaining({ labels: ['bug:버그'] }),
+    );
+  });
+
+  it('요청 labels가 있으면 repo에 존재하는 요청 labels만 사용한다', async () => {
+    apiClient.createIssue.mockResolvedValue(createdIssue);
+
+    await service.createIssue({
+      ...dto,
+      title: '로그인 500 에러',
+      labels: ['bug'],
+    });
+
+    expect(apiClient.createIssue).toHaveBeenCalledWith(
+      'token',
+      expect.objectContaining({ labels: ['bug'] }),
+    );
+  });
+
+  it('요청 labels가 repo에 없으면 라벨을 생성하고 사용한다', async () => {
+    apiClient.createIssue.mockResolvedValue(createdIssue);
+
+    await service.createIssue({
+      ...dto,
+      labels: ['unknown'],
+    });
+
+    expect(apiClient.createIssue).toHaveBeenCalledWith(
+      'token',
+      expect.objectContaining({ labels: ['unknown'] }),
+    );
+    expect(apiClient.createLabel).toHaveBeenCalledWith(
+      'token',
+      expect.any(Object),
+      expect.objectContaining({
+        name: 'unknown',
+        color: 'ededed',
+      }),
+    );
+  });
+
+  it('repo 라벨이 비어 있으면 cowork 기본 라벨을 생성하고 분류에 사용한다', async () => {
+    apiClient.listLabels.mockResolvedValue([]);
+    apiClient.createIssue.mockResolvedValue(createdIssue);
+
+    await service.createIssue({
+      ...dto,
+      title: '로그인 500 에러',
+    });
+
+    expect(apiClient.createLabel).toHaveBeenCalledWith(
+      'token',
+      expect.any(Object),
+      expect.objectContaining({ name: 'bug:버그' }),
+    );
+    expect(apiClient.createIssue).toHaveBeenCalledWith(
+      'token',
+      expect.objectContaining({ labels: ['bug:버그'] }),
+    );
+  });
+
+  it('애매한 이상 표현은 bug 라벨로 분류한다', async () => {
+    apiClient.createIssue.mockResolvedValue(createdIssue);
+
+    await service.createIssue({
+      ...dto,
+      title: '로그인 쪽이 이상해요',
+    });
+
+    expect(apiClient.createIssue).toHaveBeenCalledWith(
+      'token',
+      expect.objectContaining({ labels: ['bug:버그'] }),
+    );
+  });
+
+  it('repo의 실제 라벨명이 prefix 형태면 해당 라벨명을 사용한다', async () => {
+    apiClient.createIssue.mockResolvedValue(createdIssue);
+
+    await service.createIssue({
+      ...dto,
+      title: '기능 추가 요청',
+    });
+
+    expect(apiClient.createIssue).toHaveBeenCalledWith(
+      'token',
+      expect.objectContaining({ labels: ['enhancement:개선작업'] }),
+    );
+  });
+
+  it('기존 이슈가 있으면 새 이슈를 만들지 않고 라벨만 추가한다', async () => {
+    apiClient.searchOpenIssuesByTitle.mockResolvedValue([
+      {
+        number: 7,
+        html_url: 'https://github.com/team-cowork/cowork-github/issues/7',
+        title: '로그인 500 에러',
+      },
+    ]);
+
+    await service.createIssue({
+      ...dto,
+      title: '로그인 500 에러',
+    });
+
+    expect(apiClient.addLabelsToIssue).toHaveBeenCalledWith(
+      'token',
+      expect.any(Object),
+      7,
+      ['bug:버그'],
+    );
+    expect(apiClient.createIssue).not.toHaveBeenCalled();
+  });
+
+  it('기존 이슈가 있고 키워드 매칭이 안 되면 fallback 라벨을 추가한다', async () => {
+    apiClient.searchOpenIssuesByTitle.mockResolvedValue([
+      {
+        number: 7,
+        html_url: 'https://github.com/team-cowork/cowork-github/issues/7',
+        title: 'Issue title',
+      },
+    ]);
 
     await service.createIssue(dto);
 
-    expect(apiClient.createIssue).toHaveBeenCalledTimes(3);
+    expect(apiClient.addLabelsToIssue).toHaveBeenCalledWith(
+      'token',
+      expect.any(Object),
+      7,
+      ['help wanted:도움 필요'],
+    );
+    expect(apiClient.createIssue).not.toHaveBeenCalled();
+  });
+
+  it('일시적 오류 발생 시 성공할 때까지 재시도한다', async () => {
+    apiClient.searchOpenIssuesByTitle
+      .mockRejectedValueOnce(new Error('temporary error'))
+      .mockRejectedValueOnce(new Error('temporary error'))
+      .mockResolvedValueOnce([]);
+    apiClient.createIssue.mockResolvedValueOnce(createdIssue);
+
+    await service.createIssue(dto);
+
+    expect(apiClient.searchOpenIssuesByTitle).toHaveBeenCalledTimes(3);
+    expect(apiClient.createIssue).toHaveBeenCalledTimes(1);
   });
 
   it('GithubClientError는 재시도 없이 즉시 던진다', async () => {
     const error = new GithubClientError('invalid request', 422);
-    apiClient.createIssue.mockRejectedValue(error);
+    apiClient.searchOpenIssuesByTitle.mockRejectedValue(error);
 
     await expect(service.createIssue(dto)).rejects.toThrow(error);
-    expect(apiClient.createIssue).toHaveBeenCalledTimes(1);
+    expect(apiClient.searchOpenIssuesByTitle).toHaveBeenCalledTimes(1);
+    expect(apiClient.createIssue).not.toHaveBeenCalled();
   });
 
   it('최대 재시도 횟수 초과 시 마지막 에러를 던진다', async () => {
     const error = new Error('persistent server error');
-    apiClient.createIssue.mockRejectedValue(error);
+    apiClient.searchOpenIssuesByTitle.mockRejectedValue(error);
 
     await expect(service.createIssue(dto)).rejects.toThrow(error);
-    expect(apiClient.createIssue).toHaveBeenCalledTimes(3);
+    expect(apiClient.searchOpenIssuesByTitle).toHaveBeenCalledTimes(3);
+    expect(apiClient.createIssue).not.toHaveBeenCalled();
   });
 
   it('재시도 사이에 지수 백오프를 적용한다', async () => {
     const sleepSpy = jest.spyOn(service as any, 'sleep');
-    apiClient.createIssue
+    apiClient.searchOpenIssuesByTitle
       .mockRejectedValueOnce(new Error('fail'))
       .mockRejectedValueOnce(new Error('fail'))
-      .mockResolvedValueOnce(createdIssue);
+      .mockResolvedValueOnce([]);
+    apiClient.createIssue.mockResolvedValueOnce(createdIssue);
 
     await service.createIssue(dto);
 

--- a/src/github/issue/issue.service.spec.ts
+++ b/src/github/issue/issue.service.spec.ts
@@ -5,6 +5,7 @@ import { GithubApiClient } from '../client/github-api.client';
 import { CreateIssueDto } from '../dto/create-issue.dto';
 import { GithubClientError } from '../github.errors';
 import { IssueService } from './issue.service';
+import { LabelService } from './label.service';
 
 describe('IssueService', () => {
   let service: IssueService;
@@ -13,9 +14,8 @@ describe('IssueService', () => {
     createIssue: jest.Mock;
     searchOpenIssuesByTitle: jest.Mock;
     addLabelsToIssue: jest.Mock;
-    listLabels: jest.Mock;
-    createLabel: jest.Mock;
   };
+  let labelService: { ensureUsableLabels: jest.Mock; resolveLabels: jest.Mock };
 
   const dto: CreateIssueDto = {
     owner: 'team-cowork',
@@ -28,24 +28,21 @@ describe('IssueService', () => {
     html_url: 'https://github.com/team-cowork/cowork-github/issues/1',
   };
 
+  const REPO_LABELS = ['bug:버그', 'help wanted:도움 필요'];
+  const RESOLVED_LABELS = ['help wanted:도움 필요'];
+
   beforeEach(async () => {
     authService = {
       getInstallationToken: jest.fn().mockResolvedValue('token'),
     };
     apiClient = {
-      createIssue: jest.fn(),
+      createIssue: jest.fn().mockResolvedValue(createdIssue),
       searchOpenIssuesByTitle: jest.fn().mockResolvedValue([]),
       addLabelsToIssue: jest.fn().mockResolvedValue(undefined),
-      createLabel: jest.fn().mockResolvedValue(undefined),
-      listLabels: jest
-        .fn()
-        .mockResolvedValue([
-          'bug',
-          'bug:버그',
-          'enhancement:개선작업',
-          'help wanted:도움 필요',
-          'waiting for review:검토 대기',
-        ]),
+    };
+    labelService = {
+      ensureUsableLabels: jest.fn().mockResolvedValue(REPO_LABELS),
+      resolveLabels: jest.fn().mockReturnValue(RESOLVED_LABELS),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -54,6 +51,7 @@ describe('IssueService', () => {
         { provide: AppConfigService, useValue: { githubIssueMaxRetries: 3 } },
         { provide: GithubAuthService, useValue: authService },
         { provide: GithubApiClient, useValue: apiClient },
+        { provide: LabelService, useValue: labelService },
       ],
     }).compile();
 
@@ -61,146 +59,23 @@ describe('IssueService', () => {
     jest.spyOn(service as any, 'sleep').mockResolvedValue(undefined);
   });
 
-  it('정상 처리 시 getInstallationToken과 createIssue를 호출한다', async () => {
-    apiClient.createIssue.mockResolvedValue(createdIssue);
-
+  it('정상 처리 시 라벨을 해석하고 이슈를 생성한다', async () => {
     await service.createIssue(dto);
 
     expect(authService.getInstallationToken).toHaveBeenCalledWith(dto.owner);
+    expect(labelService.ensureUsableLabels).toHaveBeenCalledWith('token', dto);
+    expect(labelService.resolveLabels).toHaveBeenCalledWith(dto, REPO_LABELS);
     expect(apiClient.searchOpenIssuesByTitle).toHaveBeenCalledWith(
       'token',
       dto,
     );
     expect(apiClient.createIssue).toHaveBeenCalledWith('token', {
       ...dto,
-      labels: ['help wanted:도움 필요'],
+      labels: RESOLVED_LABELS,
     });
-  });
-
-  it('요청 labels가 없으면 repo 라벨 중 키워드 기반 라벨을 추론해 새 이슈에 붙인다', async () => {
-    apiClient.createIssue.mockResolvedValue(createdIssue);
-
-    await service.createIssue({
-      ...dto,
-      title: '로그인 500 에러',
-      body: '카카오 로그인 실패',
-    });
-
-    expect(apiClient.createIssue).toHaveBeenCalledWith(
-      'token',
-      expect.objectContaining({ labels: ['bug:버그'] }),
-    );
-  });
-
-  it('요청 labels가 있으면 repo에 존재하는 요청 labels만 사용한다', async () => {
-    apiClient.createIssue.mockResolvedValue(createdIssue);
-
-    await service.createIssue({
-      ...dto,
-      title: '로그인 500 에러',
-      labels: ['bug'],
-    });
-
-    expect(apiClient.createIssue).toHaveBeenCalledWith(
-      'token',
-      expect.objectContaining({ labels: ['bug'] }),
-    );
-  });
-
-  it('요청 labels가 repo에 없으면 라벨을 생성하고 사용한다', async () => {
-    apiClient.createIssue.mockResolvedValue(createdIssue);
-
-    await service.createIssue({
-      ...dto,
-      labels: ['unknown'],
-    });
-
-    expect(apiClient.createIssue).toHaveBeenCalledWith(
-      'token',
-      expect.objectContaining({ labels: ['unknown'] }),
-    );
-    expect(apiClient.createLabel).toHaveBeenCalledWith(
-      'token',
-      expect.any(Object),
-      expect.objectContaining({
-        name: 'unknown',
-        color: 'ededed',
-      }),
-    );
-  });
-
-  it('repo 라벨이 비어 있으면 cowork 기본 라벨을 생성하고 분류에 사용한다', async () => {
-    apiClient.listLabels.mockResolvedValue([]);
-    apiClient.createIssue.mockResolvedValue(createdIssue);
-
-    await service.createIssue({
-      ...dto,
-      title: '로그인 500 에러',
-    });
-
-    expect(apiClient.createLabel).toHaveBeenCalledWith(
-      'token',
-      expect.any(Object),
-      expect.objectContaining({ name: 'bug:버그' }),
-    );
-    expect(apiClient.createIssue).toHaveBeenCalledWith(
-      'token',
-      expect.objectContaining({ labels: ['bug:버그'] }),
-    );
-  });
-
-  it('애매한 이상 표현은 bug 라벨로 분류한다', async () => {
-    apiClient.createIssue.mockResolvedValue(createdIssue);
-
-    await service.createIssue({
-      ...dto,
-      title: '로그인 쪽이 이상해요',
-    });
-
-    expect(apiClient.createIssue).toHaveBeenCalledWith(
-      'token',
-      expect.objectContaining({ labels: ['bug:버그'] }),
-    );
-  });
-
-  it('repo의 실제 라벨명이 prefix 형태면 해당 라벨명을 사용한다', async () => {
-    apiClient.createIssue.mockResolvedValue(createdIssue);
-
-    await service.createIssue({
-      ...dto,
-      title: '기능 추가 요청',
-    });
-
-    expect(apiClient.createIssue).toHaveBeenCalledWith(
-      'token',
-      expect.objectContaining({ labels: ['enhancement:개선작업'] }),
-    );
   });
 
   it('기존 이슈가 있으면 새 이슈를 만들지 않고 라벨만 추가한다', async () => {
-    apiClient.searchOpenIssuesByTitle.mockResolvedValue([
-      {
-        number: 7,
-        html_url: 'https://github.com/team-cowork/cowork-github/issues/7',
-        title: '로그인 500 에러',
-      },
-    ]);
-
-    await service.createIssue({
-      ...dto,
-      title: '로그인 500 에러',
-    });
-
-    expect(apiClient.addLabelsToIssue).toHaveBeenCalledWith(
-      'token',
-      expect.any(Object),
-      7,
-      ['bug:버그'],
-    );
-    expect(apiClient.createIssue).not.toHaveBeenCalled();
-  });
-
-  it('기존 이슈가 있고 키워드 매칭이 안 되면 fallback 라벨을 추가한다', async () => {
     apiClient.searchOpenIssuesByTitle.mockResolvedValue([
       {
         number: 7,
@@ -213,10 +88,26 @@ describe('IssueService', () => {
 
     expect(apiClient.addLabelsToIssue).toHaveBeenCalledWith(
       'token',
-      expect.any(Object),
+      dto,
       7,
-      ['help wanted:도움 필요'],
+      RESOLVED_LABELS,
     );
+    expect(apiClient.createIssue).not.toHaveBeenCalled();
+  });
+
+  it('기존 이슈가 있고 라벨이 없으면 addLabelsToIssue를 호출하지 않는다', async () => {
+    apiClient.searchOpenIssuesByTitle.mockResolvedValue([
+      {
+        number: 7,
+        html_url: 'https://github.com/team-cowork/cowork-github/issues/7',
+        title: 'Issue title',
+      },
+    ]);
+    labelService.resolveLabels.mockReturnValue([]);
+
+    await service.createIssue(dto);
+
+    expect(apiClient.addLabelsToIssue).not.toHaveBeenCalled();
     expect(apiClient.createIssue).not.toHaveBeenCalled();
   });
 
@@ -225,7 +116,6 @@ describe('IssueService', () => {
       .mockRejectedValueOnce(new Error('temporary error'))
       .mockRejectedValueOnce(new Error('temporary error'))
       .mockResolvedValueOnce([]);
-    apiClient.createIssue.mockResolvedValueOnce(createdIssue);
 
     await service.createIssue(dto);
 
@@ -248,7 +138,6 @@ describe('IssueService', () => {
 
     await expect(service.createIssue(dto)).rejects.toThrow(error);
     expect(apiClient.searchOpenIssuesByTitle).toHaveBeenCalledTimes(3);
-    expect(apiClient.createIssue).not.toHaveBeenCalled();
   });
 
   it('재시도 사이에 지수 백오프를 적용한다', async () => {
@@ -257,11 +146,10 @@ describe('IssueService', () => {
       .mockRejectedValueOnce(new Error('fail'))
       .mockRejectedValueOnce(new Error('fail'))
       .mockResolvedValueOnce([]);
-    apiClient.createIssue.mockResolvedValueOnce(createdIssue);
 
     await service.createIssue(dto);
 
-    expect(sleepSpy).toHaveBeenNthCalledWith(1, 1000); // 2^0 * 1000
-    expect(sleepSpy).toHaveBeenNthCalledWith(2, 2000); // 2^1 * 1000
+    expect(sleepSpy).toHaveBeenNthCalledWith(1, 1000);
+    expect(sleepSpy).toHaveBeenNthCalledWith(2, 2000);
   });
 });

--- a/src/github/issue/issue.service.ts
+++ b/src/github/issue/issue.service.ts
@@ -33,7 +33,9 @@ export class IssueService {
           token,
           dto,
         );
-        const existingIssue = existingIssues[0];
+        const existingIssue = existingIssues.find(
+          (issue) => issue.title === dto.title,
+        );
 
         if (existingIssue) {
           if (labels.length > 0) {

--- a/src/github/issue/issue.service.ts
+++ b/src/github/issue/issue.service.ts
@@ -1,12 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { AppConfigService } from '../../config/app-config.service';
-import {
-  CreateLabelPayload,
-  GithubApiClient,
-} from '../client/github-api.client';
+import { GithubApiClient } from '../client/github-api.client';
 import { GithubAuthService } from '../auth/github-auth.service';
 import { CreateIssueDto } from '../dto/create-issue.dto';
 import { GithubClientError } from '../github.errors';
+import { LabelService } from './label.service';
 
 @Injectable()
 export class IssueService {
@@ -16,6 +14,7 @@ export class IssueService {
     private readonly config: AppConfigService,
     private readonly authService: GithubAuthService,
     private readonly apiClient: GithubApiClient,
+    private readonly labelService: LabelService,
   ) {}
 
   async createIssue(dto: CreateIssueDto): Promise<void> {
@@ -24,25 +23,12 @@ export class IssueService {
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
         const token = await this.authService.getInstallationToken(dto.owner);
-        const repoLabels = await this.ensureUsableLabels(token, dto);
-        this.logger.log('Repository labels loaded', {
-          owner: dto.owner,
-          repo: dto.repo,
-          labelCount: repoLabels.length,
-        });
+        const repoLabels = await this.labelService.ensureUsableLabels(
+          token,
+          dto,
+        );
+        const labels = this.labelService.resolveLabels(dto, repoLabels);
 
-        const labels = this.resolveLabels(dto, repoLabels);
-        this.logger.log('Issue labels resolved', {
-          owner: dto.owner,
-          repo: dto.repo,
-          title: dto.title,
-          labels,
-        });
-
-        const issueDto = {
-          ...dto,
-          labels: labels.length > 0 ? labels : undefined,
-        };
         const existingIssues = await this.apiClient.searchOpenIssuesByTitle(
           token,
           dto,
@@ -64,11 +50,19 @@ export class IssueService {
               labels,
             });
           }
-          this.logger.log(`Existing issue found: ${existingIssue.html_url}`);
+          this.logger.log('Existing issue found', {
+            owner: dto.owner,
+            repo: dto.repo,
+            issueNumber: existingIssue.number,
+            issueUrl: existingIssue.html_url,
+          });
           return;
         }
 
-        const result = await this.apiClient.createIssue(token, issueDto);
+        const result = await this.apiClient.createIssue(token, {
+          ...dto,
+          labels: labels.length > 0 ? labels : undefined,
+        });
         this.logger.log('Issue created', {
           owner: dto.owner,
           repo: dto.repo,
@@ -97,254 +91,4 @@ export class IssueService {
   private sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
-
-  private async ensureUsableLabels(
-    token: string,
-    dto: CreateIssueDto,
-  ): Promise<string[]> {
-    const repoLabels = await this.apiClient.listLabels(token, dto);
-    const requestedLabels = dto.labels ?? [];
-
-    if (repoLabels.length === 0) {
-      await this.createMissingLabels(token, dto, COWORK_DEFAULT_LABELS, []);
-      const defaultLabelNames = COWORK_DEFAULT_LABELS.map(
-        (label) => label.name,
-      );
-      await this.createRequestedLabels(
-        token,
-        dto,
-        requestedLabels,
-        defaultLabelNames,
-      );
-      return this.uniqueLabels([...defaultLabelNames, ...requestedLabels]);
-    }
-
-    await this.createRequestedLabels(token, dto, requestedLabels, repoLabels);
-    return this.uniqueLabels([...repoLabels, ...requestedLabels]);
-  }
-
-  private async createRequestedLabels(
-    token: string,
-    dto: CreateIssueDto,
-    requestedLabels: string[],
-    existingLabels: string[],
-  ): Promise<void> {
-    const labelsToCreate = this.uniqueLabels(requestedLabels)
-      .filter((label) => label.trim().length > 0)
-      .filter((label) => !this.hasRepoLabel(existingLabels, label))
-      .map((label) => this.createCustomLabel(label));
-
-    await this.createMissingLabels(token, dto, labelsToCreate, existingLabels);
-  }
-
-  private async createMissingLabels(
-    token: string,
-    dto: CreateIssueDto,
-    labels: CreateLabelPayload[],
-    existingLabels: string[],
-  ): Promise<void> {
-    for (const label of labels) {
-      if (this.hasRepoLabel(existingLabels, label.name)) continue;
-
-      try {
-        await this.apiClient.createLabel(token, dto, label);
-        this.logger.log('Repository label created', {
-          owner: dto.owner,
-          repo: dto.repo,
-          label: label.name,
-        });
-      } catch (error) {
-        if (
-          error instanceof GithubClientError &&
-          (error.statusCode === 422 || error.statusCode === 403)
-        ) {
-          this.logger.log(
-            `Repository label creation skipped (status: ${error.statusCode})`,
-            {
-              owner: dto.owner,
-              repo: dto.repo,
-              label: label.name,
-            },
-          );
-          continue;
-        }
-        throw error;
-      }
-    }
-  }
-
-  private resolveLabels(dto: CreateIssueDto, repoLabels: string[]): string[] {
-    if (dto.labels && dto.labels.length > 0) {
-      const requestedLabels = dto.labels.filter((label) =>
-        this.hasRepoLabel(repoLabels, label),
-      );
-      if (requestedLabels.length > 0) return requestedLabels;
-    }
-
-    const text = `${dto.title} ${dto.body ?? ''}`.toLowerCase();
-    if (this.includesAny(text, BUG_KEYWORDS)) {
-      return this.matchRepoLabels(repoLabels, BUG_LABEL_CANDIDATES);
-    }
-    if (this.includesAny(text, ENHANCEMENT_KEYWORDS)) {
-      return this.matchRepoLabels(repoLabels, ENHANCEMENT_LABEL_CANDIDATES);
-    }
-    if (this.includesAny(text, QUESTION_KEYWORDS)) {
-      return this.matchRepoLabels(repoLabels, QUESTION_LABEL_CANDIDATES);
-    }
-    return this.matchRepoLabels(repoLabels, FALLBACK_LABEL_CANDIDATES);
-  }
-
-  private includesAny(text: string, keywords: readonly string[]): boolean {
-    return keywords.some((keyword) => text.includes(keyword));
-  }
-
-  private matchRepoLabels(
-    repoLabels: string[],
-    candidates: readonly string[],
-  ): string[] {
-    const normalizedRepoLabels = repoLabels.map((label) => ({
-      label,
-      normalized: label.toLowerCase(),
-    }));
-
-    for (const candidate of candidates) {
-      const normalizedCandidate = candidate.toLowerCase();
-      const exactMatch = normalizedRepoLabels.find(
-        ({ normalized }) => normalized === normalizedCandidate,
-      );
-      if (exactMatch) return [exactMatch.label];
-
-      const prefixMatch = normalizedRepoLabels.find(({ normalized }) =>
-        normalized.startsWith(`${normalizedCandidate}:`),
-      );
-      if (prefixMatch) return [prefixMatch.label];
-    }
-
-    return [];
-  }
-
-  private hasRepoLabel(repoLabels: string[], label: string): boolean {
-    const normalizedLabel = label.toLowerCase();
-    return repoLabels.some(
-      (repoLabel) => repoLabel.toLowerCase() === normalizedLabel,
-    );
-  }
-
-  private uniqueLabels(labels: string[]): string[] {
-    const seen = new Set<string>();
-    const unique: string[] = [];
-
-    for (const label of labels) {
-      const normalized = label.toLowerCase();
-      if (seen.has(normalized)) continue;
-      seen.add(normalized);
-      unique.push(label);
-    }
-
-    return unique;
-  }
-
-  private createCustomLabel(name: string): CreateLabelPayload {
-    return {
-      name,
-      color: 'ededed',
-      description: '사용자 요청으로 생성된 라벨',
-    };
-  }
 }
-
-const COWORK_DEFAULT_LABELS: CreateLabelPayload[] = [
-  {
-    name: 'blocked:차단됨',
-    color: 'b60205',
-    description: '진행이 차단된 이슈',
-  },
-  { name: 'bug:버그', color: 'd73a4a', description: '버그 또는 오작동' },
-  {
-    name: 'documentation:문서화',
-    color: '0075ca',
-    description: '문서 작성 또는 수정',
-  },
-  { name: 'duplicate:중복', color: 'cfd3d7', description: '중복 이슈' },
-  {
-    name: 'enhancement:개선작업',
-    color: 'a2eeef',
-    description: '기능 추가 또는 개선',
-  },
-  {
-    name: 'GFI:첫 기여 추천',
-    color: '7057ff',
-    description: '첫 기여자에게 추천할 만한 작업',
-  },
-  {
-    name: 'help wanted:도움 필요',
-    color: '008672',
-    description: '도움이나 추가 논의가 필요한 이슈',
-  },
-  {
-    name: 'invalid:무효한',
-    color: 'e4e669',
-    description: '유효하지 않은 이슈',
-  },
-  { name: 'release:릴리즈', color: '5319e7', description: '릴리즈 관련 작업' },
-  {
-    name: 'waiting for review:검토 대기',
-    color: 'fbca04',
-    description: '검토 대기 상태',
-  },
-];
-
-const BUG_KEYWORDS = [
-  'error',
-  'bug',
-  'fail',
-  'exception',
-  'crash',
-  '500',
-  '오류',
-  '에러',
-  '실패',
-  '안됨',
-  '안돼',
-  '안되',
-  '이상',
-  '문제',
-  '오작동',
-  '먹통',
-] as const;
-
-const ENHANCEMENT_KEYWORDS = [
-  'feature',
-  'enhancement',
-  'support',
-  '추가',
-  '개선',
-  '요청',
-  '기능',
-] as const;
-
-const QUESTION_KEYWORDS = [
-  'question',
-  'how',
-  '문의',
-  '질문',
-  '어떻게',
-  '가능',
-] as const;
-
-const BUG_LABEL_CANDIDATES = ['bug:버그', 'bug'] as const;
-const ENHANCEMENT_LABEL_CANDIDATES = [
-  'enhancement',
-  'enhancement:개선작업',
-] as const;
-const QUESTION_LABEL_CANDIDATES = [
-  'question',
-  'help wanted:도움 필요',
-] as const;
-const FALLBACK_LABEL_CANDIDATES = [
-  'help wanted:도움 필요',
-  'waiting for review:검토 대기',
-  'question',
-  'enhancement:개선작업',
-  'bug:버그',
-] as const;

--- a/src/github/issue/issue.service.ts
+++ b/src/github/issue/issue.service.ts
@@ -154,12 +154,18 @@ export class IssueService {
           label: label.name,
         });
       } catch (error) {
-        if (error instanceof GithubClientError && error.statusCode === 422) {
-          this.logger.log('Repository label already exists', {
-            owner: dto.owner,
-            repo: dto.repo,
-            label: label.name,
-          });
+        if (
+          error instanceof GithubClientError &&
+          (error.statusCode === 422 || error.statusCode === 403)
+        ) {
+          this.logger.log(
+            `Repository label creation skipped (status: ${error.statusCode})`,
+            {
+              owner: dto.owner,
+              repo: dto.repo,
+              label: label.name,
+            },
+          );
           continue;
         }
         throw error;

--- a/src/github/issue/issue.service.ts
+++ b/src/github/issue/issue.service.ts
@@ -1,6 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { AppConfigService } from '../../config/app-config.service';
-import { GithubApiClient } from '../client/github-api.client';
+import {
+  CreateLabelPayload,
+  GithubApiClient,
+} from '../client/github-api.client';
 import { GithubAuthService } from '../auth/github-auth.service';
 import { CreateIssueDto } from '../dto/create-issue.dto';
 import { GithubClientError } from '../github.errors';
@@ -21,8 +24,58 @@ export class IssueService {
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
         const token = await this.authService.getInstallationToken(dto.owner);
-        const result = await this.apiClient.createIssue(token, dto);
-        this.logger.log(`Issue created: ${result.html_url}`);
+        const repoLabels = await this.ensureUsableLabels(token, dto);
+        this.logger.log('Repository labels loaded', {
+          owner: dto.owner,
+          repo: dto.repo,
+          labelCount: repoLabels.length,
+        });
+
+        const labels = this.resolveLabels(dto, repoLabels);
+        this.logger.log('Issue labels resolved', {
+          owner: dto.owner,
+          repo: dto.repo,
+          title: dto.title,
+          labels,
+        });
+
+        const issueDto = {
+          ...dto,
+          labels: labels.length > 0 ? labels : undefined,
+        };
+        const existingIssues = await this.apiClient.searchOpenIssuesByTitle(
+          token,
+          dto,
+        );
+        const existingIssue = existingIssues[0];
+
+        if (existingIssue) {
+          if (labels.length > 0) {
+            await this.apiClient.addLabelsToIssue(
+              token,
+              dto,
+              existingIssue.number,
+              labels,
+            );
+            this.logger.log('Labels added to existing issue', {
+              owner: dto.owner,
+              repo: dto.repo,
+              issueNumber: existingIssue.number,
+              labels,
+            });
+          }
+          this.logger.log(`Existing issue found: ${existingIssue.html_url}`);
+          return;
+        }
+
+        const result = await this.apiClient.createIssue(token, issueDto);
+        this.logger.log('Issue created', {
+          owner: dto.owner,
+          repo: dto.repo,
+          issueNumber: result.number,
+          issueUrl: result.html_url,
+          labels,
+        });
         return;
       } catch (error) {
         if (error instanceof GithubClientError) throw error;
@@ -44,4 +97,248 @@ export class IssueService {
   private sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
+
+  private async ensureUsableLabels(
+    token: string,
+    dto: CreateIssueDto,
+  ): Promise<string[]> {
+    const repoLabels = await this.apiClient.listLabels(token, dto);
+    const requestedLabels = dto.labels ?? [];
+
+    if (repoLabels.length === 0) {
+      await this.createMissingLabels(token, dto, COWORK_DEFAULT_LABELS, []);
+      const defaultLabelNames = COWORK_DEFAULT_LABELS.map(
+        (label) => label.name,
+      );
+      await this.createRequestedLabels(
+        token,
+        dto,
+        requestedLabels,
+        defaultLabelNames,
+      );
+      return this.uniqueLabels([...defaultLabelNames, ...requestedLabels]);
+    }
+
+    await this.createRequestedLabels(token, dto, requestedLabels, repoLabels);
+    return this.uniqueLabels([...repoLabels, ...requestedLabels]);
+  }
+
+  private async createRequestedLabels(
+    token: string,
+    dto: CreateIssueDto,
+    requestedLabels: string[],
+    existingLabels: string[],
+  ): Promise<void> {
+    const labelsToCreate = this.uniqueLabels(requestedLabels)
+      .filter((label) => label.trim().length > 0)
+      .filter((label) => !this.hasRepoLabel(existingLabels, label))
+      .map((label) => this.createCustomLabel(label));
+
+    await this.createMissingLabels(token, dto, labelsToCreate, existingLabels);
+  }
+
+  private async createMissingLabels(
+    token: string,
+    dto: CreateIssueDto,
+    labels: CreateLabelPayload[],
+    existingLabels: string[],
+  ): Promise<void> {
+    for (const label of labels) {
+      if (this.hasRepoLabel(existingLabels, label.name)) continue;
+
+      try {
+        await this.apiClient.createLabel(token, dto, label);
+        this.logger.log('Repository label created', {
+          owner: dto.owner,
+          repo: dto.repo,
+          label: label.name,
+        });
+      } catch (error) {
+        if (error instanceof GithubClientError && error.statusCode === 422) {
+          this.logger.log('Repository label already exists', {
+            owner: dto.owner,
+            repo: dto.repo,
+            label: label.name,
+          });
+          continue;
+        }
+        throw error;
+      }
+    }
+  }
+
+  private resolveLabels(dto: CreateIssueDto, repoLabels: string[]): string[] {
+    if (dto.labels && dto.labels.length > 0) {
+      const requestedLabels = dto.labels.filter((label) =>
+        this.hasRepoLabel(repoLabels, label),
+      );
+      if (requestedLabels.length > 0) return requestedLabels;
+    }
+
+    const text = `${dto.title} ${dto.body ?? ''}`.toLowerCase();
+    if (this.includesAny(text, BUG_KEYWORDS)) {
+      return this.matchRepoLabels(repoLabels, BUG_LABEL_CANDIDATES);
+    }
+    if (this.includesAny(text, ENHANCEMENT_KEYWORDS)) {
+      return this.matchRepoLabels(repoLabels, ENHANCEMENT_LABEL_CANDIDATES);
+    }
+    if (this.includesAny(text, QUESTION_KEYWORDS)) {
+      return this.matchRepoLabels(repoLabels, QUESTION_LABEL_CANDIDATES);
+    }
+    return this.matchRepoLabels(repoLabels, FALLBACK_LABEL_CANDIDATES);
+  }
+
+  private includesAny(text: string, keywords: readonly string[]): boolean {
+    return keywords.some((keyword) => text.includes(keyword));
+  }
+
+  private matchRepoLabels(
+    repoLabels: string[],
+    candidates: readonly string[],
+  ): string[] {
+    const normalizedRepoLabels = repoLabels.map((label) => ({
+      label,
+      normalized: label.toLowerCase(),
+    }));
+
+    for (const candidate of candidates) {
+      const normalizedCandidate = candidate.toLowerCase();
+      const exactMatch = normalizedRepoLabels.find(
+        ({ normalized }) => normalized === normalizedCandidate,
+      );
+      if (exactMatch) return [exactMatch.label];
+
+      const prefixMatch = normalizedRepoLabels.find(({ normalized }) =>
+        normalized.startsWith(`${normalizedCandidate}:`),
+      );
+      if (prefixMatch) return [prefixMatch.label];
+    }
+
+    return [];
+  }
+
+  private hasRepoLabel(repoLabels: string[], label: string): boolean {
+    const normalizedLabel = label.toLowerCase();
+    return repoLabels.some(
+      (repoLabel) => repoLabel.toLowerCase() === normalizedLabel,
+    );
+  }
+
+  private uniqueLabels(labels: string[]): string[] {
+    const seen = new Set<string>();
+    const unique: string[] = [];
+
+    for (const label of labels) {
+      const normalized = label.toLowerCase();
+      if (seen.has(normalized)) continue;
+      seen.add(normalized);
+      unique.push(label);
+    }
+
+    return unique;
+  }
+
+  private createCustomLabel(name: string): CreateLabelPayload {
+    return {
+      name,
+      color: 'ededed',
+      description: '사용자 요청으로 생성된 라벨',
+    };
+  }
 }
+
+const COWORK_DEFAULT_LABELS: CreateLabelPayload[] = [
+  {
+    name: 'blocked:차단됨',
+    color: 'b60205',
+    description: '진행이 차단된 이슈',
+  },
+  { name: 'bug:버그', color: 'd73a4a', description: '버그 또는 오작동' },
+  {
+    name: 'documentation:문서화',
+    color: '0075ca',
+    description: '문서 작성 또는 수정',
+  },
+  { name: 'duplicate:중복', color: 'cfd3d7', description: '중복 이슈' },
+  {
+    name: 'enhancement:개선작업',
+    color: 'a2eeef',
+    description: '기능 추가 또는 개선',
+  },
+  {
+    name: 'GFI:첫 기여 추천',
+    color: '7057ff',
+    description: '첫 기여자에게 추천할 만한 작업',
+  },
+  {
+    name: 'help wanted:도움 필요',
+    color: '008672',
+    description: '도움이나 추가 논의가 필요한 이슈',
+  },
+  {
+    name: 'invalid:무효한',
+    color: 'e4e669',
+    description: '유효하지 않은 이슈',
+  },
+  { name: 'release:릴리즈', color: '5319e7', description: '릴리즈 관련 작업' },
+  {
+    name: 'waiting for review:검토 대기',
+    color: 'fbca04',
+    description: '검토 대기 상태',
+  },
+];
+
+const BUG_KEYWORDS = [
+  'error',
+  'bug',
+  'fail',
+  'exception',
+  'crash',
+  '500',
+  '오류',
+  '에러',
+  '실패',
+  '안됨',
+  '안돼',
+  '안되',
+  '이상',
+  '문제',
+  '오작동',
+  '먹통',
+] as const;
+
+const ENHANCEMENT_KEYWORDS = [
+  'feature',
+  'enhancement',
+  'support',
+  '추가',
+  '개선',
+  '요청',
+  '기능',
+] as const;
+
+const QUESTION_KEYWORDS = [
+  'question',
+  'how',
+  '문의',
+  '질문',
+  '어떻게',
+  '가능',
+] as const;
+
+const BUG_LABEL_CANDIDATES = ['bug:버그', 'bug'] as const;
+const ENHANCEMENT_LABEL_CANDIDATES = [
+  'enhancement',
+  'enhancement:개선작업',
+] as const;
+const QUESTION_LABEL_CANDIDATES = [
+  'question',
+  'help wanted:도움 필요',
+] as const;
+const FALLBACK_LABEL_CANDIDATES = [
+  'help wanted:도움 필요',
+  'waiting for review:검토 대기',
+  'question',
+  'enhancement:개선작업',
+  'bug:버그',
+] as const;

--- a/src/github/issue/label.constants.ts
+++ b/src/github/issue/label.constants.ts
@@ -1,7 +1,11 @@
 import type { CreateLabelPayload } from '../client/github-api.client';
 
 export const COWORK_DEFAULT_LABELS: CreateLabelPayload[] = [
-  { name: 'blocked:차단됨', color: 'b60205', description: '진행이 차단된 이슈' },
+  {
+    name: 'blocked:차단됨',
+    color: 'b60205',
+    description: '진행이 차단된 이슈',
+  },
   { name: 'bug:버그', color: 'd73a4a', description: '버그 또는 오작동' },
   {
     name: 'documentation:문서화',
@@ -24,7 +28,11 @@ export const COWORK_DEFAULT_LABELS: CreateLabelPayload[] = [
     color: '008672',
     description: '도움이나 추가 논의가 필요한 이슈',
   },
-  { name: 'invalid:무효한', color: 'e4e669', description: '유효하지 않은 이슈' },
+  {
+    name: 'invalid:무효한',
+    color: 'e4e669',
+    description: '유효하지 않은 이슈',
+  },
   { name: 'release:릴리즈', color: '5319e7', description: '릴리즈 관련 작업' },
   {
     name: 'waiting for review:검토 대기',

--- a/src/github/issue/label.constants.ts
+++ b/src/github/issue/label.constants.ts
@@ -1,0 +1,89 @@
+import type { CreateLabelPayload } from '../client/github-api.client';
+
+export const COWORK_DEFAULT_LABELS: CreateLabelPayload[] = [
+  { name: 'blocked:차단됨', color: 'b60205', description: '진행이 차단된 이슈' },
+  { name: 'bug:버그', color: 'd73a4a', description: '버그 또는 오작동' },
+  {
+    name: 'documentation:문서화',
+    color: '0075ca',
+    description: '문서 작성 또는 수정',
+  },
+  { name: 'duplicate:중복', color: 'cfd3d7', description: '중복 이슈' },
+  {
+    name: 'enhancement:개선작업',
+    color: 'a2eeef',
+    description: '기능 추가 또는 개선',
+  },
+  {
+    name: 'GFI:첫 기여 추천',
+    color: '7057ff',
+    description: '첫 기여자에게 추천할 만한 작업',
+  },
+  {
+    name: 'help wanted:도움 필요',
+    color: '008672',
+    description: '도움이나 추가 논의가 필요한 이슈',
+  },
+  { name: 'invalid:무효한', color: 'e4e669', description: '유효하지 않은 이슈' },
+  { name: 'release:릴리즈', color: '5319e7', description: '릴리즈 관련 작업' },
+  {
+    name: 'waiting for review:검토 대기',
+    color: 'fbca04',
+    description: '검토 대기 상태',
+  },
+];
+
+export const BUG_KEYWORDS = [
+  'error',
+  'bug',
+  'fail',
+  'exception',
+  'crash',
+  '500',
+  '오류',
+  '에러',
+  '실패',
+  '안됨',
+  '안돼',
+  '안되',
+  '이상',
+  '문제',
+  '오작동',
+  '먹통',
+] as const;
+
+export const ENHANCEMENT_KEYWORDS = [
+  'feature',
+  'enhancement',
+  'support',
+  '추가',
+  '개선',
+  '요청',
+  '기능',
+] as const;
+
+export const QUESTION_KEYWORDS = [
+  'question',
+  'how',
+  '문의',
+  '질문',
+  '어떻게',
+  '가능',
+] as const;
+
+export const BUG_LABEL_CANDIDATES = ['bug:버그', 'bug'] as const;
+export const ENHANCEMENT_LABEL_CANDIDATES = [
+  'enhancement',
+  'enhancement:개선작업',
+] as const;
+export const QUESTION_LABEL_CANDIDATES = [
+  'question',
+  'help wanted:도움 필요',
+] as const;
+export const FALLBACK_LABEL_CANDIDATES = [
+  'help wanted:도움 필요',
+  'waiting for review:검토 대기',
+  'question',
+  'enhancement:개선작업',
+  'bug:버그',
+] as const;

--- a/src/github/issue/label.service.spec.ts
+++ b/src/github/issue/label.service.spec.ts
@@ -96,6 +96,19 @@ describe('LabelService', () => {
         service.ensureUsableLabels('token', dto),
       ).resolves.not.toThrow();
     });
+
+    it('요청 labels 생성 시 403 에러로 스킵되면 반환 목록에 포함하지 않는다', async () => {
+      apiClient.createLabel.mockRejectedValue(
+        new GithubClientError('forbidden', 403),
+      );
+
+      const result = await service.ensureUsableLabels('token', {
+        ...dto,
+        labels: ['unknown-label'],
+      });
+
+      expect(result).not.toContain('unknown-label');
+    });
   });
 
   describe('resolveLabels', () => {

--- a/src/github/issue/label.service.spec.ts
+++ b/src/github/issue/label.service.spec.ts
@@ -153,10 +153,9 @@ describe('LabelService', () => {
     });
 
     it('repo 라벨명이 prefix 형태면 해당 라벨명으로 매칭한다', () => {
-      const result = service.resolveLabels(
-        { ...dto, title: '기능 개선' },
-        ['enhancement:개선작업'],
-      );
+      const result = service.resolveLabels({ ...dto, title: '기능 개선' }, [
+        'enhancement:개선작업',
+      ]);
       expect(result).toEqual(['enhancement:개선작업']);
     });
 

--- a/src/github/issue/label.service.spec.ts
+++ b/src/github/issue/label.service.spec.ts
@@ -1,0 +1,160 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GithubApiClient } from '../client/github-api.client';
+import { CreateIssueDto } from '../dto/create-issue.dto';
+import { GithubClientError } from '../github.errors';
+import { LabelService } from './label.service';
+
+describe('LabelService', () => {
+  let service: LabelService;
+  let apiClient: { listLabels: jest.Mock; createLabel: jest.Mock };
+
+  const dto: CreateIssueDto = {
+    owner: 'my-org',
+    repo: 'my-repo',
+    title: 'Issue title',
+  };
+
+  const defaultRepoLabels = [
+    'bug',
+    'bug:버그',
+    'enhancement:개선작업',
+    'help wanted:도움 필요',
+    'waiting for review:검토 대기',
+  ];
+
+  beforeEach(async () => {
+    apiClient = {
+      listLabels: jest.fn().mockResolvedValue(defaultRepoLabels),
+      createLabel: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LabelService,
+        { provide: GithubApiClient, useValue: apiClient },
+      ],
+    }).compile();
+
+    service = module.get<LabelService>(LabelService);
+  });
+
+  describe('ensureUsableLabels', () => {
+    it('repo 라벨이 있으면 새 라벨을 생성하지 않는다', async () => {
+      await service.ensureUsableLabels('token', dto);
+      expect(apiClient.createLabel).not.toHaveBeenCalled();
+    });
+
+    it('요청 labels가 repo에 없으면 생성하고 반환 목록에 포함한다', async () => {
+      const result = await service.ensureUsableLabels('token', {
+        ...dto,
+        labels: ['unknown-label'],
+      });
+
+      expect(apiClient.createLabel).toHaveBeenCalledWith(
+        'token',
+        expect.any(Object),
+        expect.objectContaining({ name: 'unknown-label', color: 'ededed' }),
+      );
+      expect(result).toContain('unknown-label');
+    });
+
+    it('요청 labels가 repo에 이미 있으면 생성하지 않는다', async () => {
+      await service.ensureUsableLabels('token', { ...dto, labels: ['bug'] });
+      expect(apiClient.createLabel).not.toHaveBeenCalled();
+    });
+
+    it('repo 라벨이 비어 있으면 cowork 기본 라벨을 생성한다', async () => {
+      apiClient.listLabels.mockResolvedValue([]);
+
+      await service.ensureUsableLabels('token', dto);
+
+      expect(apiClient.createLabel).toHaveBeenCalledWith(
+        'token',
+        expect.any(Object),
+        expect.objectContaining({ name: 'bug:버그' }),
+      );
+    });
+
+    it('라벨 생성 시 422 에러는 이미 존재하는 것으로 간주하고 스킵한다', async () => {
+      apiClient.listLabels.mockResolvedValue([]);
+      apiClient.createLabel.mockRejectedValue(
+        new GithubClientError('already exists', 422),
+      );
+
+      await expect(
+        service.ensureUsableLabels('token', dto),
+      ).resolves.not.toThrow();
+    });
+
+    it('라벨 생성 시 403 에러는 권한 없음으로 간주하고 스킵한다', async () => {
+      apiClient.listLabels.mockResolvedValue([]);
+      apiClient.createLabel.mockRejectedValue(
+        new GithubClientError('forbidden', 403),
+      );
+
+      await expect(
+        service.ensureUsableLabels('token', dto),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('resolveLabels', () => {
+    it('요청 labels가 있고 repo에 존재하면 해당 labels를 반환한다', () => {
+      const result = service.resolveLabels(
+        { ...dto, labels: ['bug'] },
+        defaultRepoLabels,
+      );
+      expect(result).toEqual(['bug']);
+    });
+
+    it('요청 labels가 repo에 없으면 키워드 기반으로 추론한다', () => {
+      const result = service.resolveLabels(
+        { ...dto, title: '로그인 500 에러', labels: ['nonexistent'] },
+        defaultRepoLabels,
+      );
+      expect(result).toEqual(['bug:버그']);
+    });
+
+    it('bug 키워드 포함 시 bug 라벨을 반환한다', () => {
+      const result = service.resolveLabels(
+        { ...dto, title: '로그인 500 에러', body: '카카오 로그인 실패' },
+        defaultRepoLabels,
+      );
+      expect(result).toEqual(['bug:버그']);
+    });
+
+    it('애매한 이상 표현은 bug 라벨로 분류한다', () => {
+      const result = service.resolveLabels(
+        { ...dto, title: '로그인 쪽이 이상해요' },
+        defaultRepoLabels,
+      );
+      expect(result).toEqual(['bug:버그']);
+    });
+
+    it('enhancement 키워드 포함 시 enhancement 라벨을 반환한다', () => {
+      const result = service.resolveLabels(
+        { ...dto, title: '기능 추가 요청' },
+        defaultRepoLabels,
+      );
+      expect(result).toEqual(['enhancement:개선작업']);
+    });
+
+    it('repo 라벨명이 prefix 형태면 해당 라벨명으로 매칭한다', () => {
+      const result = service.resolveLabels(
+        { ...dto, title: '기능 개선' },
+        ['enhancement:개선작업'],
+      );
+      expect(result).toEqual(['enhancement:개선작업']);
+    });
+
+    it('키워드가 없으면 fallback 라벨을 반환한다', () => {
+      const result = service.resolveLabels(dto, defaultRepoLabels);
+      expect(result).toEqual(['help wanted:도움 필요']);
+    });
+
+    it('repo에 매칭 라벨이 없으면 빈 배열을 반환한다', () => {
+      const result = service.resolveLabels(dto, ['release:릴리즈']);
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/github/issue/label.service.ts
+++ b/src/github/issue/label.service.ts
@@ -30,19 +30,28 @@ export class LabelService {
     const requestedLabels = dto.labels ?? [];
 
     if (repoLabels.length === 0) {
-      await this.createMissingLabels(token, dto, COWORK_DEFAULT_LABELS, []);
-      const defaultLabelNames = COWORK_DEFAULT_LABELS.map((l) => l.name);
-      await this.createRequestedLabels(
+      const createdDefaults = await this.createMissingLabels(
+        token,
+        dto,
+        COWORK_DEFAULT_LABELS,
+        [],
+      );
+      const handledRequested = await this.createRequestedLabels(
         token,
         dto,
         requestedLabels,
-        defaultLabelNames,
+        createdDefaults,
       );
-      return this.uniqueLabels([...defaultLabelNames, ...requestedLabels]);
+      return this.uniqueLabels([...createdDefaults, ...handledRequested]);
     }
 
-    await this.createRequestedLabels(token, dto, requestedLabels, repoLabels);
-    return this.uniqueLabels([...repoLabels, ...requestedLabels]);
+    const handledRequested = await this.createRequestedLabels(
+      token,
+      dto,
+      requestedLabels,
+      repoLabels,
+    );
+    return this.uniqueLabels([...repoLabels, ...handledRequested]);
   }
 
   resolveLabels(dto: CreateIssueDto, repoLabels: string[]): string[] {
@@ -71,13 +80,23 @@ export class LabelService {
     dto: CreateIssueDto,
     requestedLabels: string[],
     existingLabels: string[],
-  ): Promise<void> {
+  ): Promise<string[]> {
+    const alreadyExisting = this.uniqueLabels(requestedLabels).filter((label) =>
+      this.hasRepoLabel(existingLabels, label),
+    );
+
     const labelsToCreate = this.uniqueLabels(requestedLabels)
       .filter((label) => label.trim().length > 0)
       .filter((label) => !this.hasRepoLabel(existingLabels, label))
       .map((label) => this.createCustomLabel(label));
 
-    await this.createMissingLabels(token, dto, labelsToCreate, existingLabels);
+    const newlyCreated = await this.createMissingLabels(
+      token,
+      dto,
+      labelsToCreate,
+      existingLabels,
+    );
+    return this.uniqueLabels([...alreadyExisting, ...newlyCreated]);
   }
 
   private async createMissingLabels(
@@ -85,7 +104,8 @@ export class LabelService {
     dto: CreateIssueDto,
     labels: CreateLabelPayload[],
     existingLabels: string[],
-  ): Promise<void> {
+  ): Promise<string[]> {
+    const created: string[] = [];
     for (const label of labels) {
       if (this.hasRepoLabel(existingLabels, label.name)) continue;
 
@@ -96,6 +116,7 @@ export class LabelService {
           repo: dto.repo,
           label: label.name,
         });
+        created.push(label.name);
       } catch (error) {
         if (
           error instanceof GithubClientError &&
@@ -114,6 +135,7 @@ export class LabelService {
         throw error;
       }
     }
+    return created;
   }
 
   private includesAny(text: string, keywords: readonly string[]): boolean {

--- a/src/github/issue/label.service.ts
+++ b/src/github/issue/label.service.ts
@@ -183,6 +183,10 @@ export class LabelService {
   }
 
   private createCustomLabel(name: string): CreateLabelPayload {
-    return { name, color: 'ededed', description: '사용자 요청으로 생성된 라벨' };
+    return {
+      name,
+      color: 'ededed',
+      description: '사용자 요청으로 생성된 라벨',
+    };
   }
 }

--- a/src/github/issue/label.service.ts
+++ b/src/github/issue/label.service.ts
@@ -1,0 +1,166 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  CreateLabelPayload,
+  GithubApiClient,
+} from '../client/github-api.client';
+import { CreateIssueDto } from '../dto/create-issue.dto';
+import { GithubClientError } from '../github.errors';
+import {
+  BUG_KEYWORDS,
+  BUG_LABEL_CANDIDATES,
+  COWORK_DEFAULT_LABELS,
+  ENHANCEMENT_KEYWORDS,
+  ENHANCEMENT_LABEL_CANDIDATES,
+  FALLBACK_LABEL_CANDIDATES,
+  QUESTION_KEYWORDS,
+  QUESTION_LABEL_CANDIDATES,
+} from './label.constants';
+
+@Injectable()
+export class LabelService {
+  private readonly logger = new Logger(LabelService.name);
+
+  constructor(private readonly apiClient: GithubApiClient) {}
+
+  async ensureUsableLabels(
+    token: string,
+    dto: CreateIssueDto,
+  ): Promise<string[]> {
+    const repoLabels = await this.apiClient.listLabels(token, dto);
+    const requestedLabels = dto.labels ?? [];
+
+    if (repoLabels.length === 0) {
+      await this.createMissingLabels(token, dto, COWORK_DEFAULT_LABELS, []);
+      const defaultLabelNames = COWORK_DEFAULT_LABELS.map((l) => l.name);
+      await this.createRequestedLabels(
+        token,
+        dto,
+        requestedLabels,
+        defaultLabelNames,
+      );
+      return this.uniqueLabels([...defaultLabelNames, ...requestedLabels]);
+    }
+
+    await this.createRequestedLabels(token, dto, requestedLabels, repoLabels);
+    return this.uniqueLabels([...repoLabels, ...requestedLabels]);
+  }
+
+  resolveLabels(dto: CreateIssueDto, repoLabels: string[]): string[] {
+    if (dto.labels && dto.labels.length > 0) {
+      const matched = dto.labels.filter((label) =>
+        this.hasRepoLabel(repoLabels, label),
+      );
+      if (matched.length > 0) return matched;
+    }
+
+    const text = `${dto.title} ${dto.body ?? ''}`.toLowerCase();
+    if (this.includesAny(text, BUG_KEYWORDS)) {
+      return this.matchRepoLabels(repoLabels, BUG_LABEL_CANDIDATES);
+    }
+    if (this.includesAny(text, ENHANCEMENT_KEYWORDS)) {
+      return this.matchRepoLabels(repoLabels, ENHANCEMENT_LABEL_CANDIDATES);
+    }
+    if (this.includesAny(text, QUESTION_KEYWORDS)) {
+      return this.matchRepoLabels(repoLabels, QUESTION_LABEL_CANDIDATES);
+    }
+    return this.matchRepoLabels(repoLabels, FALLBACK_LABEL_CANDIDATES);
+  }
+
+  private async createRequestedLabels(
+    token: string,
+    dto: CreateIssueDto,
+    requestedLabels: string[],
+    existingLabels: string[],
+  ): Promise<void> {
+    const labelsToCreate = this.uniqueLabels(requestedLabels)
+      .filter((label) => label.trim().length > 0)
+      .filter((label) => !this.hasRepoLabel(existingLabels, label))
+      .map((label) => this.createCustomLabel(label));
+
+    await this.createMissingLabels(token, dto, labelsToCreate, existingLabels);
+  }
+
+  private async createMissingLabels(
+    token: string,
+    dto: CreateIssueDto,
+    labels: CreateLabelPayload[],
+    existingLabels: string[],
+  ): Promise<void> {
+    for (const label of labels) {
+      if (this.hasRepoLabel(existingLabels, label.name)) continue;
+
+      try {
+        await this.apiClient.createLabel(token, dto, label);
+        this.logger.log('Repository label created', {
+          owner: dto.owner,
+          repo: dto.repo,
+          label: label.name,
+        });
+      } catch (error) {
+        if (
+          error instanceof GithubClientError &&
+          (error.statusCode === 422 || error.statusCode === 403)
+        ) {
+          this.logger.log(
+            `Repository label creation skipped (status: ${error.statusCode})`,
+            {
+              owner: dto.owner,
+              repo: dto.repo,
+              label: label.name,
+            },
+          );
+          continue;
+        }
+        throw error;
+      }
+    }
+  }
+
+  private includesAny(text: string, keywords: readonly string[]): boolean {
+    return keywords.some((keyword) => text.includes(keyword));
+  }
+
+  private matchRepoLabels(
+    repoLabels: string[],
+    candidates: readonly string[],
+  ): string[] {
+    const normalized = repoLabels.map((label) => ({
+      label,
+      lower: label.toLowerCase(),
+    }));
+
+    for (const candidate of candidates) {
+      const lowerCandidate = candidate.toLowerCase();
+      const exact = normalized.find(({ lower }) => lower === lowerCandidate);
+      if (exact) return [exact.label];
+
+      const prefix = normalized.find(({ lower }) =>
+        lower.startsWith(`${lowerCandidate}:`),
+      );
+      if (prefix) return [prefix.label];
+    }
+
+    return [];
+  }
+
+  private hasRepoLabel(repoLabels: string[], label: string): boolean {
+    const lower = label.toLowerCase();
+    return repoLabels.some((l) => l.toLowerCase() === lower);
+  }
+
+  private uniqueLabels(labels: string[]): string[] {
+    const seen = new Set<string>();
+    const result: string[] = [];
+    for (const label of labels) {
+      const lower = label.toLowerCase();
+      if (seen.has(lower)) continue;
+      seen.add(lower);
+      result.push(label);
+    }
+    return result;
+  }
+
+  private createCustomLabel(name: string): CreateLabelPayload {
+    return { name, color: 'ededed', description: '사용자 요청으로 생성된 라벨' };
+  }
+}


### PR DESCRIPTION
## 개요

GitHub Issue 생성 시 제목 기반으로 중복 이슈를 감지하고, 이슈 내용에 맞는 라벨을 자동으로 분류·부착하는 기능을 추가하였습니다. 또한 `GithubApiClient`에 이슈 검색 및 라벨 관련 API 메서드를 추가하였습니다.

## 본문

**중복 이슈 감지**

이슈 생성 전 GitHub Search API로 동일 제목의 열린 이슈를 조회합니다. 기존 이슈가 존재하면 새 이슈를 생성하지 않고, 라벨만 추가한 뒤 처리를 종료합니다.

**라벨 자동 분류**

요청에 `labels`가 포함된 경우 repo에 존재하는 라벨만 사용하고, 없는 라벨은 새로 생성합니다. `labels`가 없는 경우 이슈 제목·본문 키워드를 분석해 bug / enhancement / question / fallback 순서로 라벨을 추론합니다. repo의 실제 라벨명이 `bug:버그`처럼 prefix 형태인 경우에도 정확히 매칭됩니다.

**기본 라벨 초기화**

repo에 라벨이 하나도 없으면 `COWORK_DEFAULT_LABELS`(10종)를 자동 생성한 뒤 분류를 진행합니다.

**GithubApiClient 확장**

`searchOpenIssuesByTitle`, `addLabelsToIssue`, `listLabels`, `createLabel` 메서드를 추가하였습니다. 기존 `createIssue`와 동일한 `handleGithubError` private 메서드로 에러 처리를 통일하였습니다.
