### PR TITLE
[github] 기존 이슈 중복 라벨 방지 및 누락 기본 라벨 자동 생성

### DIFF
--- a/src/github/client/github-api.client.spec.ts
+++ b/src/github/client/github-api.client.spec.ts
@@ -125,6 +125,7 @@ describe('GithubApiClient', () => {
               number: 7,
               html_url: 'https://github.com/my-org/my-repo/issues/7',
               title: 'Bug fix',
+              labels: [{ name: 'bug' }],
             },
           ],
         },
@@ -138,6 +139,7 @@ describe('GithubApiClient', () => {
         number: 7,
         html_url: 'https://github.com/my-org/my-repo/issues/7',
         title: 'Bug fix',
+        labels: [{ name: 'bug' }],
       },
     ]);
     expect(httpService.get).toHaveBeenCalledWith(

--- a/src/github/client/github-api.client.ts
+++ b/src/github/client/github-api.client.ts
@@ -15,6 +15,7 @@ export interface SearchedIssue {
   number: number;
   html_url: string;
   title: string;
+  labels: { name: string }[];
 }
 
 export interface GithubLabel {
@@ -56,7 +57,9 @@ export class GithubApiClient {
     dto: CreateIssueDto,
   ): Promise<SearchedIssue[]> {
     try {
-      const escapedTitle = dto.title.replace(/"/g, '\\"');
+      const escapedTitle = dto.title
+        .replace(/\\/g, '\\\\')
+        .replace(/"/g, '\\"');
       const query = `repo:${dto.owner}/${dto.repo} is:issue is:open in:title "${escapedTitle}"`;
       const { data } = await firstValueFrom(
         this.httpService.get<{ items: SearchedIssue[] }>(
@@ -71,6 +74,7 @@ export class GithubApiClient {
         number: item.number,
         html_url: item.html_url,
         title: item.title,
+        labels: (item.labels ?? []).map((l) => ({ name: l.name })),
       }));
     } catch (error) {
       this.handleGithubError(error);

--- a/src/github/issue/issue.service.spec.ts
+++ b/src/github/issue/issue.service.spec.ts
@@ -81,6 +81,7 @@ describe('IssueService', () => {
         number: 7,
         html_url: 'https://github.com/team-cowork/cowork-github/issues/7',
         title: 'Issue title',
+        labels: [],
       },
     ]);
 
@@ -95,12 +96,35 @@ describe('IssueService', () => {
     expect(apiClient.createIssue).not.toHaveBeenCalled();
   });
 
+  it('기존 이슈가 이미 라벨을 가지고 있으면 중복 라벨 추가를 건너뛴다', async () => {
+    apiClient.searchOpenIssuesByTitle.mockResolvedValue([
+      {
+        number: 7,
+        html_url: 'https://github.com/team-cowork/cowork-github/issues/7',
+        title: 'Issue title',
+        labels: [{ name: 'help wanted:도움 필요' }],
+      },
+    ]);
+    labelService.resolveLabels.mockReturnValue([
+      'help wanted:도움 필요',
+      'bug:버그',
+    ]);
+
+    await service.createIssue(dto);
+
+    expect(apiClient.addLabelsToIssue).toHaveBeenCalledWith('token', dto, 7, [
+      'bug:버그',
+    ]);
+    expect(apiClient.createIssue).not.toHaveBeenCalled();
+  });
+
   it('기존 이슈가 있고 라벨이 없으면 addLabelsToIssue를 호출하지 않는다', async () => {
     apiClient.searchOpenIssuesByTitle.mockResolvedValue([
       {
         number: 7,
         html_url: 'https://github.com/team-cowork/cowork-github/issues/7',
         title: 'Issue title',
+        labels: [{ name: 'help wanted:도움 필요' }],
       },
     ]);
     labelService.resolveLabels.mockReturnValue([]);

--- a/src/github/issue/issue.service.ts
+++ b/src/github/issue/issue.service.ts
@@ -38,18 +38,26 @@ export class IssueService {
         );
 
         if (existingIssue) {
-          if (labels.length > 0) {
+          const newLabels = labels.filter(
+            (label) =>
+              !existingIssue.labels.some(
+                (existingLabel) =>
+                  existingLabel.name.toLowerCase() === label.toLowerCase(),
+              ),
+          );
+
+          if (newLabels.length > 0) {
             await this.apiClient.addLabelsToIssue(
               token,
               dto,
               existingIssue.number,
-              labels,
+              newLabels,
             );
             this.logger.log('Labels added to existing issue', {
               owner: dto.owner,
               repo: dto.repo,
               issueNumber: existingIssue.number,
-              labels,
+              labels: newLabels,
             });
           }
           this.logger.log('Existing issue found', {

--- a/src/github/issue/label.service.spec.ts
+++ b/src/github/issue/label.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { GithubApiClient } from '../client/github-api.client';
 import { CreateIssueDto } from '../dto/create-issue.dto';
 import { GithubClientError } from '../github.errors';
+import { COWORK_DEFAULT_LABELS } from './label.constants';
 import { LabelService } from './label.service';
 
 describe('LabelService', () => {
@@ -14,17 +15,14 @@ describe('LabelService', () => {
     title: 'Issue title',
   };
 
-  const defaultRepoLabels = [
-    'bug',
-    'bug:버그',
-    'enhancement:개선작업',
-    'help wanted:도움 필요',
-    'waiting for review:검토 대기',
-  ];
+  const fullDefaultRepoLabels = COWORK_DEFAULT_LABELS.map(
+    (label) => label.name,
+  );
+  const partialDefaultRepoLabels = ['bug:버그'];
 
   beforeEach(async () => {
     apiClient = {
-      listLabels: jest.fn().mockResolvedValue(defaultRepoLabels),
+      listLabels: jest.fn().mockResolvedValue(fullDefaultRepoLabels),
       createLabel: jest.fn().mockResolvedValue(undefined),
     };
 
@@ -59,20 +57,36 @@ describe('LabelService', () => {
     });
 
     it('요청 labels가 repo에 이미 있으면 생성하지 않는다', async () => {
-      await service.ensureUsableLabels('token', { ...dto, labels: ['bug'] });
+      await service.ensureUsableLabels('token', {
+        ...dto,
+        labels: ['bug:버그'],
+      });
       expect(apiClient.createLabel).not.toHaveBeenCalled();
     });
 
-    it('repo 라벨이 비어 있으면 cowork 기본 라벨을 생성한다', async () => {
-      apiClient.listLabels.mockResolvedValue([]);
+    it('repo에 일부 기본 라벨만 있어도 누락된 기본 라벨을 생성한다', async () => {
+      apiClient.listLabels.mockResolvedValue(partialDefaultRepoLabels);
 
       await service.ensureUsableLabels('token', dto);
 
       expect(apiClient.createLabel).toHaveBeenCalledWith(
         'token',
         expect.any(Object),
-        expect.objectContaining({ name: 'bug:버그' }),
+        expect.objectContaining({ name: 'blocked:차단됨' }),
       );
+      expect(apiClient.createLabel).toHaveBeenCalledWith(
+        'token',
+        expect.any(Object),
+        expect.objectContaining({ name: 'enhancement:개선작업' }),
+      );
+    });
+
+    it('모든 기본 라벨이 이미 있으면 기본 라벨을 추가 생성하지 않는다', async () => {
+      apiClient.listLabels.mockResolvedValue(fullDefaultRepoLabels);
+
+      await service.ensureUsableLabels('token', dto);
+
+      expect(apiClient.createLabel).not.toHaveBeenCalled();
     });
 
     it('라벨 생성 시 422 에러는 이미 존재하는 것으로 간주하고 스킵한다', async () => {
@@ -114,16 +128,16 @@ describe('LabelService', () => {
   describe('resolveLabels', () => {
     it('요청 labels가 있고 repo에 존재하면 해당 labels를 반환한다', () => {
       const result = service.resolveLabels(
-        { ...dto, labels: ['bug'] },
-        defaultRepoLabels,
+        { ...dto, labels: ['bug:버그'] },
+        fullDefaultRepoLabels,
       );
-      expect(result).toEqual(['bug']);
+      expect(result).toEqual(['bug:버그']);
     });
 
     it('요청 labels가 repo에 없으면 키워드 기반으로 추론한다', () => {
       const result = service.resolveLabels(
         { ...dto, title: '로그인 500 에러', labels: ['nonexistent'] },
-        defaultRepoLabels,
+        fullDefaultRepoLabels,
       );
       expect(result).toEqual(['bug:버그']);
     });
@@ -131,7 +145,7 @@ describe('LabelService', () => {
     it('bug 키워드 포함 시 bug 라벨을 반환한다', () => {
       const result = service.resolveLabels(
         { ...dto, title: '로그인 500 에러', body: '카카오 로그인 실패' },
-        defaultRepoLabels,
+        fullDefaultRepoLabels,
       );
       expect(result).toEqual(['bug:버그']);
     });
@@ -139,7 +153,7 @@ describe('LabelService', () => {
     it('애매한 이상 표현은 bug 라벨로 분류한다', () => {
       const result = service.resolveLabels(
         { ...dto, title: '로그인 쪽이 이상해요' },
-        defaultRepoLabels,
+        fullDefaultRepoLabels,
       );
       expect(result).toEqual(['bug:버그']);
     });
@@ -147,7 +161,7 @@ describe('LabelService', () => {
     it('enhancement 키워드 포함 시 enhancement 라벨을 반환한다', () => {
       const result = service.resolveLabels(
         { ...dto, title: '기능 추가 요청' },
-        defaultRepoLabels,
+        fullDefaultRepoLabels,
       );
       expect(result).toEqual(['enhancement:개선작업']);
     });
@@ -160,7 +174,7 @@ describe('LabelService', () => {
     });
 
     it('키워드가 없으면 fallback 라벨을 반환한다', () => {
-      const result = service.resolveLabels(dto, defaultRepoLabels);
+      const result = service.resolveLabels(dto, fullDefaultRepoLabels);
       expect(result).toEqual(['help wanted:도움 필요']);
     });
 

--- a/src/github/issue/label.service.ts
+++ b/src/github/issue/label.service.ts
@@ -29,29 +29,24 @@ export class LabelService {
     const repoLabels = await this.apiClient.listLabels(token, dto);
     const requestedLabels = dto.labels ?? [];
 
-    if (repoLabels.length === 0) {
-      const createdDefaults = await this.createMissingLabels(
-        token,
-        dto,
-        COWORK_DEFAULT_LABELS,
-        [],
-      );
-      const handledRequested = await this.createRequestedLabels(
-        token,
-        dto,
-        requestedLabels,
-        createdDefaults,
-      );
-      return this.uniqueLabels([...createdDefaults, ...handledRequested]);
-    }
+    const createdDefaults = await this.createMissingLabels(
+      token,
+      dto,
+      COWORK_DEFAULT_LABELS,
+      repoLabels,
+    );
 
     const handledRequested = await this.createRequestedLabels(
       token,
       dto,
       requestedLabels,
-      repoLabels,
+      [...repoLabels, ...createdDefaults],
     );
-    return this.uniqueLabels([...repoLabels, ...handledRequested]);
+    return this.uniqueLabels([
+      ...repoLabels,
+      ...createdDefaults,
+      ...handledRequested,
+    ]);
   }
 
   resolveLabels(dto: CreateIssueDto, repoLabels: string[]): string[] {


### PR DESCRIPTION
## 개요

기존 이슈에 이미 붙어 있는 라벨을 중복으로 추가하는 버그와, repo에 일부 기본 라벨만 존재할 때 나머지 기본 라벨이 생성되지 않는 버그를 수정하였습니다. 아울러 이슈 제목에 역슬래시가 포함된 경우 GitHub Search API 쿼리가 비정상적으로 종료되는 문제도 함께 수정하였습니다.

## 본문

**기존 이슈 라벨 중복 추가 방지**

`searchOpenIssuesByTitle`의 응답에 `labels` 필드를 추가하고, `IssueService`에서 기존 이슈에 라벨을 추가하기 전에 이미 붙어 있는 라벨을 필터링하도록 수정하였습니다. 기존에는 이미 존재하는 라벨도 무조건 `addLabelsToIssue`에 전달하여 GitHub API가 중복 처리를 하였습니다.

**누락 기본 라벨 항상 보완 생성**

`LabelService.ensureUsableLabels`에서 기존에는 repo 라벨이 완전히 비어 있을 때만 기본 라벨을 생성하였습니다. 이를 변경하여 repo 상태와 무관하게 `COWORK_DEFAULT_LABELS` 중 누락된 라벨은 항상 생성하도록 수정하였습니다.

**검색 쿼리 역슬래시 이스케이프 보완**

이슈 제목에 `\`가 포함된 경우 `"` 이스케이프 처리 전에 `\`를 먼저 이스케이프하지 않아 쿼리가 비정상적으로 구성되는 문제를 수정하였습니다.
