### PR TITLE
[github] 이슈 라벨 체계를 레포 기존 형식으로 통일

### DIFF
--- a/src/github/dto/create-issue.dto.ts
+++ b/src/github/dto/create-issue.dto.ts
@@ -1,4 +1,10 @@
-import { IsArray, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import {
+  IsArray,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 
 export class CreateIssueDto {
   @IsString()
@@ -26,4 +32,12 @@ export class CreateIssueDto {
   @IsString({ each: true })
   @IsOptional()
   assignees?: string[];
+
+  @IsNumber()
+  @IsOptional()
+  channelId?: number;
+
+  @IsNumber()
+  @IsOptional()
+  teamId?: number;
 }

--- a/src/github/github.controller.spec.ts
+++ b/src/github/github.controller.spec.ts
@@ -32,7 +32,8 @@ describe('GithubController', () => {
     }).compile();
 
     controller = module.get<GithubController>(GithubController);
-    (controller as unknown as { exitProcess: jest.Mock }).exitProcess = jest.fn();
+    (controller as unknown as { exitProcess: jest.Mock }).exitProcess =
+      jest.fn();
   });
 
   const validPayload = { owner: 'my-org', repo: 'my-repo', title: 'Bug fix' };
@@ -98,7 +99,11 @@ describe('GithubController', () => {
     });
 
     it('channelId와 teamId가 있으면 검증 실패 시 실패 결과 이벤트를 발행한다', async () => {
-      const invalidPayloadWithContext = { owner: 'my-org', channelId: 5, teamId: 1 };
+      const invalidPayloadWithContext = {
+        owner: 'my-org',
+        channelId: 5,
+        teamId: 1,
+      };
 
       await controller.handleIssueCreate(invalidPayloadWithContext, ctx);
 

--- a/src/github/github.controller.spec.ts
+++ b/src/github/github.controller.spec.ts
@@ -2,16 +2,19 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { KafkaContext } from '@nestjs/microservices';
 import { GithubController } from './github.controller';
 import { IssueService } from './issue/issue.service';
+import { IssueResultProducer } from './kafka/issue-result.producer';
 import { GithubClientError } from './github.errors';
 
 describe('GithubController', () => {
   let controller: GithubController;
   let issueService: { createIssue: jest.Mock };
+  let issueResultProducer: { send: jest.Mock };
   let commitOffsets: jest.Mock;
   let ctx: KafkaContext;
 
   beforeEach(async () => {
     issueService = { createIssue: jest.fn() };
+    issueResultProducer = { send: jest.fn().mockResolvedValue(undefined) };
     commitOffsets = jest.fn().mockResolvedValue(undefined);
     ctx = {
       getMessage: jest.fn().mockReturnValue({ offset: '5' }),
@@ -22,60 +25,129 @@ describe('GithubController', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [GithubController],
-      providers: [{ provide: IssueService, useValue: issueService }],
+      providers: [
+        { provide: IssueService, useValue: issueService },
+        { provide: IssueResultProducer, useValue: issueResultProducer },
+      ],
     }).compile();
 
     controller = module.get<GithubController>(GithubController);
-    (controller as { exitProcess: jest.Mock }).exitProcess = jest.fn();
+    (controller as unknown as { exitProcess: jest.Mock }).exitProcess = jest.fn();
   });
 
   const validPayload = { owner: 'my-org', repo: 'my-repo', title: 'Bug fix' };
+  const payloadWithContext = { ...validPayload, channelId: 5, teamId: 1 };
 
-  it('정상 처리 시 오프셋을 커밋한다', async () => {
-    issueService.createIssue.mockResolvedValue(undefined);
+  describe('정상 처리', () => {
+    it('이슈 생성 후 오프셋을 커밋한다', async () => {
+      issueService.createIssue.mockResolvedValue({
+        issueUrl: 'https://github.com/my-org/my-repo/issues/1',
+        issueNumber: 1,
+      });
 
-    await controller.handleIssueCreate(validPayload, ctx);
+      await controller.handleIssueCreate(validPayload, ctx);
 
-    expect(issueService.createIssue).toHaveBeenCalledTimes(1);
-    expect(commitOffsets).toHaveBeenCalledWith([
-      { topic: 'github.issue.create', partition: 0, offset: '6' },
-    ]);
+      expect(issueService.createIssue).toHaveBeenCalledTimes(1);
+      expect(commitOffsets).toHaveBeenCalledWith([
+        { topic: 'github.issue.create', partition: 0, offset: '6' },
+      ]);
+    });
+
+    it('channelId와 teamId가 있으면 성공 결과 이벤트를 발행한다', async () => {
+      issueService.createIssue.mockResolvedValue({
+        issueUrl: 'https://github.com/my-org/my-repo/issues/1',
+        issueNumber: 1,
+      });
+
+      await controller.handleIssueCreate(payloadWithContext, ctx);
+
+      expect(issueResultProducer.send).toHaveBeenCalledWith({
+        channelId: 5,
+        teamId: 1,
+        success: true,
+        issueUrl: 'https://github.com/my-org/my-repo/issues/1',
+        issueNumber: 1,
+      });
+    });
+
+    it('channelId가 없으면 결과 이벤트를 발행하지 않는다', async () => {
+      issueService.createIssue.mockResolvedValue({
+        issueUrl: 'https://github.com/my-org/my-repo/issues/1',
+        issueNumber: 1,
+      });
+
+      await controller.handleIssueCreate(validPayload, ctx);
+
+      expect(issueResultProducer.send).not.toHaveBeenCalled();
+    });
   });
 
-  it('필수 필드 누락 시 서비스 호출 없이 오프셋을 커밋한다 (잘못된 메시지 스킵)', async () => {
-    await controller.handleIssueCreate({ owner: 'my-org' }, ctx);
+  describe('검증 실패 (잘못된 페이로드)', () => {
+    it('필수 필드 누락 시 서비스 호출 없이 오프셋을 커밋한다', async () => {
+      await controller.handleIssueCreate({ owner: 'my-org' }, ctx);
 
-    expect(issueService.createIssue).not.toHaveBeenCalled();
-    expect(commitOffsets).toHaveBeenCalledTimes(1);
+      expect(issueService.createIssue).not.toHaveBeenCalled();
+      expect(commitOffsets).toHaveBeenCalledTimes(1);
+    });
+
+    it('payload가 객체가 아니면 서비스 호출 없이 오프셋을 커밋한다', async () => {
+      await controller.handleIssueCreate(null, ctx);
+
+      expect(issueService.createIssue).not.toHaveBeenCalled();
+      expect(commitOffsets).toHaveBeenCalledTimes(1);
+    });
+
+    it('channelId와 teamId가 있으면 검증 실패 시 실패 결과 이벤트를 발행한다', async () => {
+      const invalidPayloadWithContext = { owner: 'my-org', channelId: 5, teamId: 1 };
+
+      await controller.handleIssueCreate(invalidPayloadWithContext, ctx);
+
+      expect(issueResultProducer.send).toHaveBeenCalledWith(
+        expect.objectContaining({ channelId: 5, teamId: 1, success: false }),
+      );
+    });
   });
 
-  it('payload가 객체가 아니면 서비스 호출 없이 오프셋을 커밋한다', async () => {
-    await controller.handleIssueCreate(null, ctx);
+  describe('GitHub 클라이언트 에러 (4xx)', () => {
+    it('GithubClientError 발생 시 오프셋을 커밋한다', async () => {
+      issueService.createIssue.mockRejectedValue(
+        new GithubClientError('Repo not found', 404),
+      );
 
-    expect(issueService.createIssue).not.toHaveBeenCalled();
-    expect(commitOffsets).toHaveBeenCalledTimes(1);
+      await controller.handleIssueCreate(validPayload, ctx);
+
+      expect(commitOffsets).toHaveBeenCalledTimes(1);
+    });
+
+    it('channelId와 teamId가 있으면 클라이언트 에러 시 실패 결과 이벤트를 발행한다', async () => {
+      issueService.createIssue.mockRejectedValue(
+        new GithubClientError('Repo not found', 404),
+      );
+
+      await controller.handleIssueCreate(payloadWithContext, ctx);
+
+      expect(issueResultProducer.send).toHaveBeenCalledWith({
+        channelId: 5,
+        teamId: 1,
+        success: false,
+        error: 'Repo not found',
+      });
+      expect(commitOffsets).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it('GithubClientError 발생 시 오프셋을 커밋한다 (4xx 스킵)', async () => {
-    issueService.createIssue.mockRejectedValue(
-      new GithubClientError('Repo not found', 404),
-    );
+  describe('GitHub 서버 에러 (5xx)', () => {
+    it('서버 에러 발생 시 프로세스를 종료한다', async () => {
+      issueService.createIssue.mockRejectedValue(new Error('GitHub 503'));
 
-    await controller.handleIssueCreate(validPayload, ctx);
+      await expect(
+        controller.handleIssueCreate(validPayload, ctx),
+      ).rejects.toThrow('GitHub 503');
 
-    expect(commitOffsets).toHaveBeenCalledTimes(1);
-  });
-
-  it('서버 에러 발생 시 프로세스를 종료한다', async () => {
-    issueService.createIssue.mockRejectedValue(new Error('GitHub 503'));
-
-    await expect(
-      controller.handleIssueCreate(validPayload, ctx),
-    ).rejects.toThrow('GitHub 503');
-
-    expect(commitOffsets).not.toHaveBeenCalled();
-    expect(
-      (controller as { exitProcess: jest.Mock }).exitProcess,
-    ).toHaveBeenCalledWith(1);
+      expect(commitOffsets).not.toHaveBeenCalled();
+      expect(
+        (controller as unknown as { exitProcess: jest.Mock }).exitProcess,
+      ).toHaveBeenCalledWith(1);
+    });
   });
 });

--- a/src/github/github.controller.ts
+++ b/src/github/github.controller.ts
@@ -10,13 +10,17 @@ import { validate } from 'class-validator';
 import { CreateIssueDto } from './dto/create-issue.dto';
 import { IssueService } from './issue/issue.service';
 import { GithubClientError } from './github.errors';
+import { IssueResultProducer } from './kafka/issue-result.producer';
 
 @Controller()
 export class GithubController {
   private readonly logger = new Logger(GithubController.name);
   private readonly exitProcess = (code: number): never => process.exit(code);
 
-  constructor(private readonly issueService: IssueService) {}
+  constructor(
+    private readonly issueService: IssueService,
+    private readonly issueResultProducer: IssueResultProducer,
+  ) {}
 
   @EventPattern('github.issue.create')
   async handleIssueCreate(
@@ -40,11 +44,28 @@ export class GithubController {
       this.logger.error('Invalid payload, skipping message', {
         errors: errors.map((e) => e.toString()),
       });
+      if (dto.channelId != null && dto.teamId != null) {
+        await this.issueResultProducer.send({
+          channelId: dto.channelId,
+          teamId: dto.teamId,
+          success: false,
+          error: '잘못된 이슈 생성 요청입니다.',
+        });
+      }
       return true;
     }
 
     try {
-      await this.issueService.createIssue(dto);
+      const result = await this.issueService.createIssue(dto);
+      if (dto.channelId != null && dto.teamId != null) {
+        await this.issueResultProducer.send({
+          channelId: dto.channelId,
+          teamId: dto.teamId,
+          success: true,
+          issueUrl: result.issueUrl,
+          issueNumber: result.issueNumber,
+        });
+      }
       return true;
     } catch (error) {
       if (error instanceof GithubClientError) {
@@ -55,6 +76,14 @@ export class GithubController {
           statusCode: error.statusCode,
           message: error.message,
         });
+        if (dto.channelId != null && dto.teamId != null) {
+          await this.issueResultProducer.send({
+            channelId: dto.channelId,
+            teamId: dto.teamId,
+            success: false,
+            error: error.message,
+          });
+        }
         return true;
       }
       this.logger.error('GitHub server error, consumer will stop for retry', {

--- a/src/github/github.module.ts
+++ b/src/github/github.module.ts
@@ -8,6 +8,7 @@ import { REDIS_CLIENT } from './constants';
 import { IssueService } from './issue/issue.service';
 import { LabelService } from './issue/label.service';
 import { GithubController } from './github.controller';
+import { IssueResultProducer } from './kafka/issue-result.producer';
 
 @Module({
   imports: [HttpModule],
@@ -27,6 +28,7 @@ import { GithubController } from './github.controller';
     GithubApiClient,
     LabelService,
     IssueService,
+    IssueResultProducer,
   ],
   controllers: [GithubController],
 })

--- a/src/github/issue/issue.service.spec.ts
+++ b/src/github/issue/issue.service.spec.ts
@@ -70,8 +70,15 @@ describe('IssueService', () => {
 
     expect(authService.getInstallationToken).toHaveBeenCalledWith(dto.owner);
     expect(labelService.resolveLabels).toHaveBeenCalledWith(dto);
-    expect(labelService.ensureLabelsExist).toHaveBeenCalledWith('token', dto, RESOLVED_LABELS);
-    expect(apiClient.searchOpenIssuesByTitle).toHaveBeenCalledWith('token', dto);
+    expect(labelService.ensureLabelsExist).toHaveBeenCalledWith(
+      'token',
+      dto,
+      RESOLVED_LABELS,
+    );
+    expect(apiClient.searchOpenIssuesByTitle).toHaveBeenCalledWith(
+      'token',
+      dto,
+    );
     expect(apiClient.createIssue).toHaveBeenCalledWith('token', {
       ...dto,
       labels: RESOLVED_LABELS,
@@ -115,11 +122,16 @@ describe('IssueService', () => {
     apiClient.searchOpenIssuesByTitle.mockResolvedValue([
       { ...existingIssue, labels: [{ name: 'help wanted:도움 필요' }] },
     ]);
-    labelService.resolveLabels.mockReturnValue(['help wanted:도움 필요', 'bug:버그']);
+    labelService.resolveLabels.mockReturnValue([
+      'help wanted:도움 필요',
+      'bug:버그',
+    ]);
 
     await service.createIssue(dto);
 
-    expect(apiClient.addLabelsToIssue).toHaveBeenCalledWith('token', dto, 7, ['bug:버그']);
+    expect(apiClient.addLabelsToIssue).toHaveBeenCalledWith('token', dto, 7, [
+      'bug:버그',
+    ]);
     expect(apiClient.createIssue).not.toHaveBeenCalled();
   });
 

--- a/src/github/issue/issue.service.spec.ts
+++ b/src/github/issue/issue.service.spec.ts
@@ -35,7 +35,7 @@ describe('IssueService', () => {
     labels: [],
   };
 
-  const RESOLVED_LABELS = ['default:기본'];
+  const RESOLVED_LABELS = ['help wanted:도움 필요'];
 
   beforeEach(async () => {
     authService = {
@@ -82,14 +82,14 @@ describe('IssueService', () => {
     });
   });
 
-  it('resolveLabels가 default:기본을 반환해도 이슈 API에 labels가 전달된다', async () => {
-    labelService.resolveLabels.mockReturnValue(['default:기본']);
+  it('resolveLabels가 help wanted:도움 필요을 반환해도 이슈 API에 labels가 전달된다', async () => {
+    labelService.resolveLabels.mockReturnValue(['help wanted:도움 필요']);
 
     await service.createIssue(dto);
 
     expect(apiClient.createIssue).toHaveBeenCalledWith('token', {
       ...dto,
-      labels: ['default:기본'],
+      labels: ['help wanted:도움 필요'],
     });
   });
 
@@ -113,9 +113,9 @@ describe('IssueService', () => {
 
   it('기존 이슈가 이미 라벨을 가지고 있으면 중복 라벨 추가를 건너뛴다', async () => {
     apiClient.searchOpenIssuesByTitle.mockResolvedValue([
-      { ...existingIssue, labels: [{ name: 'default:기본' }] },
+      { ...existingIssue, labels: [{ name: 'help wanted:도움 필요' }] },
     ]);
-    labelService.resolveLabels.mockReturnValue(['default:기본', 'bug:버그']);
+    labelService.resolveLabels.mockReturnValue(['help wanted:도움 필요', 'bug:버그']);
 
     await service.createIssue(dto);
 
@@ -125,9 +125,9 @@ describe('IssueService', () => {
 
   it('기존 이슈의 라벨이 모두 이미 있으면 addLabelsToIssue를 호출하지 않는다', async () => {
     apiClient.searchOpenIssuesByTitle.mockResolvedValue([
-      { ...existingIssue, labels: [{ name: 'default:기본' }] },
+      { ...existingIssue, labels: [{ name: 'help wanted:도움 필요' }] },
     ]);
-    labelService.resolveLabels.mockReturnValue(['default:기본']);
+    labelService.resolveLabels.mockReturnValue(['help wanted:도움 필요']);
 
     await service.createIssue(dto);
 

--- a/src/github/issue/issue.service.spec.ts
+++ b/src/github/issue/issue.service.spec.ts
@@ -15,7 +15,7 @@ describe('IssueService', () => {
     searchOpenIssuesByTitle: jest.Mock;
     addLabelsToIssue: jest.Mock;
   };
-  let labelService: { ensureUsableLabels: jest.Mock; resolveLabels: jest.Mock };
+  let labelService: { resolveLabels: jest.Mock; ensureLabelsExist: jest.Mock };
 
   const dto: CreateIssueDto = {
     owner: 'team-cowork',
@@ -28,8 +28,14 @@ describe('IssueService', () => {
     html_url: 'https://github.com/team-cowork/cowork-github/issues/1',
   };
 
-  const REPO_LABELS = ['bug:버그', 'help wanted:도움 필요'];
-  const RESOLVED_LABELS = ['help wanted:도움 필요'];
+  const existingIssue = {
+    number: 7,
+    html_url: 'https://github.com/team-cowork/cowork-github/issues/7',
+    title: 'Issue title',
+    labels: [],
+  };
+
+  const RESOLVED_LABELS = ['default:기본'];
 
   beforeEach(async () => {
     authService = {
@@ -41,8 +47,8 @@ describe('IssueService', () => {
       addLabelsToIssue: jest.fn().mockResolvedValue(undefined),
     };
     labelService = {
-      ensureUsableLabels: jest.fn().mockResolvedValue(REPO_LABELS),
       resolveLabels: jest.fn().mockReturnValue(RESOLVED_LABELS),
+      ensureLabelsExist: jest.fn().mockResolvedValue(undefined),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -59,33 +65,38 @@ describe('IssueService', () => {
     jest.spyOn(service as any, 'sleep').mockResolvedValue(undefined);
   });
 
-  it('정상 처리 시 라벨을 해석하고 이슈를 생성한다', async () => {
-    await service.createIssue(dto);
+  it('정상 처리 시 라벨을 해석하고 이슈를 생성한 뒤 issueUrl과 issueNumber를 반환한다', async () => {
+    const result = await service.createIssue(dto);
 
     expect(authService.getInstallationToken).toHaveBeenCalledWith(dto.owner);
-    expect(labelService.ensureUsableLabels).toHaveBeenCalledWith('token', dto);
-    expect(labelService.resolveLabels).toHaveBeenCalledWith(dto, REPO_LABELS);
-    expect(apiClient.searchOpenIssuesByTitle).toHaveBeenCalledWith(
-      'token',
-      dto,
-    );
+    expect(labelService.resolveLabels).toHaveBeenCalledWith(dto);
+    expect(labelService.ensureLabelsExist).toHaveBeenCalledWith('token', dto, RESOLVED_LABELS);
+    expect(apiClient.searchOpenIssuesByTitle).toHaveBeenCalledWith('token', dto);
     expect(apiClient.createIssue).toHaveBeenCalledWith('token', {
       ...dto,
       labels: RESOLVED_LABELS,
     });
+    expect(result).toEqual({
+      issueUrl: 'https://github.com/team-cowork/cowork-github/issues/1',
+      issueNumber: 1,
+    });
   });
 
-  it('기존 이슈가 있으면 새 이슈를 만들지 않고 라벨만 추가한다', async () => {
-    apiClient.searchOpenIssuesByTitle.mockResolvedValue([
-      {
-        number: 7,
-        html_url: 'https://github.com/team-cowork/cowork-github/issues/7',
-        title: 'Issue title',
-        labels: [],
-      },
-    ]);
+  it('resolveLabels가 default:기본을 반환해도 이슈 API에 labels가 전달된다', async () => {
+    labelService.resolveLabels.mockReturnValue(['default:기본']);
 
     await service.createIssue(dto);
+
+    expect(apiClient.createIssue).toHaveBeenCalledWith('token', {
+      ...dto,
+      labels: ['default:기본'],
+    });
+  });
+
+  it('기존 이슈가 있으면 새 이슈를 만들지 않고 라벨만 추가한 뒤 기존 이슈 정보를 반환한다', async () => {
+    apiClient.searchOpenIssuesByTitle.mockResolvedValue([existingIssue]);
+
+    const result = await service.createIssue(dto);
 
     expect(apiClient.addLabelsToIssue).toHaveBeenCalledWith(
       'token',
@@ -94,40 +105,29 @@ describe('IssueService', () => {
       RESOLVED_LABELS,
     );
     expect(apiClient.createIssue).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      issueUrl: 'https://github.com/team-cowork/cowork-github/issues/7',
+      issueNumber: 7,
+    });
   });
 
   it('기존 이슈가 이미 라벨을 가지고 있으면 중복 라벨 추가를 건너뛴다', async () => {
     apiClient.searchOpenIssuesByTitle.mockResolvedValue([
-      {
-        number: 7,
-        html_url: 'https://github.com/team-cowork/cowork-github/issues/7',
-        title: 'Issue title',
-        labels: [{ name: 'help wanted:도움 필요' }],
-      },
+      { ...existingIssue, labels: [{ name: 'default:기본' }] },
     ]);
-    labelService.resolveLabels.mockReturnValue([
-      'help wanted:도움 필요',
-      'bug:버그',
-    ]);
+    labelService.resolveLabels.mockReturnValue(['default:기본', 'bug:버그']);
 
     await service.createIssue(dto);
 
-    expect(apiClient.addLabelsToIssue).toHaveBeenCalledWith('token', dto, 7, [
-      'bug:버그',
-    ]);
+    expect(apiClient.addLabelsToIssue).toHaveBeenCalledWith('token', dto, 7, ['bug:버그']);
     expect(apiClient.createIssue).not.toHaveBeenCalled();
   });
 
-  it('기존 이슈가 있고 라벨이 없으면 addLabelsToIssue를 호출하지 않는다', async () => {
+  it('기존 이슈의 라벨이 모두 이미 있으면 addLabelsToIssue를 호출하지 않는다', async () => {
     apiClient.searchOpenIssuesByTitle.mockResolvedValue([
-      {
-        number: 7,
-        html_url: 'https://github.com/team-cowork/cowork-github/issues/7',
-        title: 'Issue title',
-        labels: [{ name: 'help wanted:도움 필요' }],
-      },
+      { ...existingIssue, labels: [{ name: 'default:기본' }] },
     ]);
-    labelService.resolveLabels.mockReturnValue([]);
+    labelService.resolveLabels.mockReturnValue(['default:기본']);
 
     await service.createIssue(dto);
 
@@ -135,16 +135,17 @@ describe('IssueService', () => {
     expect(apiClient.createIssue).not.toHaveBeenCalled();
   });
 
-  it('일시적 오류 발생 시 성공할 때까지 재시도한다', async () => {
+  it('일시적 오류 발생 시 성공할 때까지 재시도하고 결과를 반환한다', async () => {
     apiClient.searchOpenIssuesByTitle
       .mockRejectedValueOnce(new Error('temporary error'))
       .mockRejectedValueOnce(new Error('temporary error'))
       .mockResolvedValueOnce([]);
 
-    await service.createIssue(dto);
+    const result = await service.createIssue(dto);
 
     expect(apiClient.searchOpenIssuesByTitle).toHaveBeenCalledTimes(3);
     expect(apiClient.createIssue).toHaveBeenCalledTimes(1);
+    expect(result.issueNumber).toBe(1);
   });
 
   it('GithubClientError는 재시도 없이 즉시 던진다', async () => {

--- a/src/github/issue/issue.service.ts
+++ b/src/github/issue/issue.service.ts
@@ -17,17 +17,16 @@ export class IssueService {
     private readonly labelService: LabelService,
   ) {}
 
-  async createIssue(dto: CreateIssueDto): Promise<void> {
+  async createIssue(
+    dto: CreateIssueDto,
+  ): Promise<{ issueUrl: string; issueNumber: number }> {
     const maxRetries = this.config.githubIssueMaxRetries;
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
         const token = await this.authService.getInstallationToken(dto.owner);
-        const repoLabels = await this.labelService.ensureUsableLabels(
-          token,
-          dto,
-        );
-        const labels = this.labelService.resolveLabels(dto, repoLabels);
+        const labels = this.labelService.resolveLabels(dto);
+        await this.labelService.ensureLabelsExist(token, dto, labels);
 
         const existingIssues = await this.apiClient.searchOpenIssuesByTitle(
           token,
@@ -66,12 +65,15 @@ export class IssueService {
             issueNumber: existingIssue.number,
             issueUrl: existingIssue.html_url,
           });
-          return;
+          return {
+            issueUrl: existingIssue.html_url,
+            issueNumber: existingIssue.number,
+          };
         }
 
         const result = await this.apiClient.createIssue(token, {
           ...dto,
-          labels: labels.length > 0 ? labels : undefined,
+          labels,
         });
         this.logger.log('Issue created', {
           owner: dto.owner,
@@ -80,7 +82,7 @@ export class IssueService {
           issueUrl: result.html_url,
           labels,
         });
-        return;
+        return { issueUrl: result.html_url, issueNumber: result.number };
       } catch (error) {
         if (error instanceof GithubClientError) throw error;
 
@@ -96,6 +98,7 @@ export class IssueService {
         await this.sleep(Math.pow(2, attempt - 1) * 1000);
       }
     }
+    throw new Error('createIssue: max retries exceeded without result');
   }
 
   private sleep(ms: number): Promise<void> {

--- a/src/github/issue/label.constants.ts
+++ b/src/github/issue/label.constants.ts
@@ -1,45 +1,24 @@
 import type { CreateLabelPayload } from '../client/github-api.client';
 
-export const COWORK_DEFAULT_LABELS: CreateLabelPayload[] = [
-  {
-    name: 'blocked:차단됨',
-    color: 'b60205',
-    description: '진행이 차단된 이슈',
-  },
+export const COWORK_LABELS: CreateLabelPayload[] = [
   { name: 'bug:버그', color: 'd73a4a', description: '버그 또는 오작동' },
-  {
-    name: 'documentation:문서화',
-    color: '0075ca',
-    description: '문서 작성 또는 수정',
-  },
+  { name: 'enhancement:개선작업', color: 'a2eeef', description: '기능 추가 또는 개선' },
+  { name: 'question:질문', color: 'd876e3', description: '질문 또는 문의' },
+  { name: 'default:기본', color: 'e4e669', description: '분류되지 않은 이슈' },
+  { name: 'blocked:차단됨', color: 'b60205', description: '진행이 차단된 이슈' },
   { name: 'duplicate:중복', color: 'cfd3d7', description: '중복 이슈' },
-  {
-    name: 'enhancement:개선작업',
-    color: 'a2eeef',
-    description: '기능 추가 또는 개선',
-  },
-  {
-    name: 'GFI:첫 기여 추천',
-    color: '7057ff',
-    description: '첫 기여자에게 추천할 만한 작업',
-  },
-  {
-    name: 'help wanted:도움 필요',
-    color: '008672',
-    description: '도움이나 추가 논의가 필요한 이슈',
-  },
-  {
-    name: 'invalid:무효한',
-    color: 'e4e669',
-    description: '유효하지 않은 이슈',
-  },
+  { name: 'documentation:문서화', color: '0075ca', description: '문서 작성 또는 수정' },
   { name: 'release:릴리즈', color: '5319e7', description: '릴리즈 관련 작업' },
-  {
-    name: 'waiting for review:검토 대기',
-    color: 'fbca04',
-    description: '검토 대기 상태',
-  },
+  { name: 'waiting-review:검토대기', color: 'fbca04', description: '검토 대기 상태' },
+  { name: 'first-contribution:첫기여', color: '7057ff', description: '첫 기여자에게 추천할 만한 작업' },
 ];
+
+export const COWORK_LABEL_PREFIX = '' as const;
+export const COWORK_FALLBACK_LABEL = 'default:기본' as const;
+
+export const BUG_LABEL = 'bug:버그' as const;
+export const ENHANCEMENT_LABEL = 'enhancement:개선작업' as const;
+export const QUESTION_LABEL = 'question:질문' as const;
 
 export const BUG_KEYWORDS = [
   'error',
@@ -77,21 +56,4 @@ export const QUESTION_KEYWORDS = [
   '질문',
   '어떻게',
   '가능',
-] as const;
-
-export const BUG_LABEL_CANDIDATES = ['bug:버그', 'bug'] as const;
-export const ENHANCEMENT_LABEL_CANDIDATES = [
-  'enhancement',
-  'enhancement:개선작업',
-] as const;
-export const QUESTION_LABEL_CANDIDATES = [
-  'question',
-  'help wanted:도움 필요',
-] as const;
-export const FALLBACK_LABEL_CANDIDATES = [
-  'help wanted:도움 필요',
-  'waiting for review:검토 대기',
-  'question',
-  'enhancement:개선작업',
-  'bug:버그',
 ] as const;

--- a/src/github/issue/label.constants.ts
+++ b/src/github/issue/label.constants.ts
@@ -4,17 +4,24 @@ export const COWORK_LABELS: CreateLabelPayload[] = [
   { name: 'bug:버그', color: 'd73a4a', description: '무언가 작동하지 않습니다' },
   { name: 'enhancement:개선작업', color: 'a2eeef', description: '새 기능 또는 기존 코드 개선에 관한 내용입니다' },
   { name: 'question:질문', color: 'd876e3', description: '질문 또는 문의사항이 있습니다' },
-  { name: 'default:기본', color: 'e4e669', description: '분류되지 않은 이슈입니다' },
+  { name: 'help wanted:도움 필요', color: '008672', description: '추가적인 지원이 필요합니다' },
   { name: 'blocked:차단됨', color: 'b60205', description: '해당 작업은 다른 작업에 의해 차단되었습니다' },
   { name: 'duplicate:중복', color: 'cfd3d7', description: '이 Issue 또는 Pull Request가 이미 존재합니다' },
   { name: 'documentation:문서화', color: '0075ca', description: '문서에 대한 개선 또는 추가사항이 있습니다' },
   { name: 'release:릴리즈', color: '5319e7', description: '프로젝트를 배포합니다' },
-  { name: 'waiting for review:검토 대기', color: 'fbca04', description: '확인을 대기하고 있습니다' },
-  { name: 'GFI:첫 기여 추천', color: '7057ff', description: '첫 기여로 훌륭한 Issue입니다' },
+  {
+    name: 'waiting for review:검토 대기',
+    color: 'fbca04',
+    description: '확인을 대기하고 있습니다',
+  },
+  {
+    name: 'GFI:첫 기여 추천',
+    color: '7057ff',
+    description: '첫 기여로 훌륭한 Issue입니다',
+  },
 ];
 
-export const COWORK_LABEL_PREFIX = '' as const;
-export const COWORK_FALLBACK_LABEL = 'default:기본' as const;
+export const COWORK_FALLBACK_LABEL = 'help wanted:도움 필요' as const;
 
 export const BUG_LABEL = 'bug:버그' as const;
 export const ENHANCEMENT_LABEL = 'enhancement:개선작업' as const;

--- a/src/github/issue/label.constants.ts
+++ b/src/github/issue/label.constants.ts
@@ -1,14 +1,46 @@
 import type { CreateLabelPayload } from '../client/github-api.client';
 
 export const COWORK_LABELS: CreateLabelPayload[] = [
-  { name: 'bug:버그', color: 'd73a4a', description: '무언가 작동하지 않습니다' },
-  { name: 'enhancement:개선작업', color: 'a2eeef', description: '새 기능 또는 기존 코드 개선에 관한 내용입니다' },
-  { name: 'question:질문', color: 'd876e3', description: '질문 또는 문의사항이 있습니다' },
-  { name: 'help wanted:도움 필요', color: '008672', description: '추가적인 지원이 필요합니다' },
-  { name: 'blocked:차단됨', color: 'b60205', description: '해당 작업은 다른 작업에 의해 차단되었습니다' },
-  { name: 'duplicate:중복', color: 'cfd3d7', description: '이 Issue 또는 Pull Request가 이미 존재합니다' },
-  { name: 'documentation:문서화', color: '0075ca', description: '문서에 대한 개선 또는 추가사항이 있습니다' },
-  { name: 'release:릴리즈', color: '5319e7', description: '프로젝트를 배포합니다' },
+  {
+    name: 'bug:버그',
+    color: 'd73a4a',
+    description: '무언가 작동하지 않습니다',
+  },
+  {
+    name: 'enhancement:개선작업',
+    color: 'a2eeef',
+    description: '새 기능 또는 기존 코드 개선에 관한 내용입니다',
+  },
+  {
+    name: 'question:질문',
+    color: 'd876e3',
+    description: '질문 또는 문의사항이 있습니다',
+  },
+  {
+    name: 'help wanted:도움 필요',
+    color: '008672',
+    description: '추가적인 지원이 필요합니다',
+  },
+  {
+    name: 'blocked:차단됨',
+    color: 'b60205',
+    description: '해당 작업은 다른 작업에 의해 차단되었습니다',
+  },
+  {
+    name: 'duplicate:중복',
+    color: 'cfd3d7',
+    description: '이 Issue 또는 Pull Request가 이미 존재합니다',
+  },
+  {
+    name: 'documentation:문서화',
+    color: '0075ca',
+    description: '문서에 대한 개선 또는 추가사항이 있습니다',
+  },
+  {
+    name: 'release:릴리즈',
+    color: '5319e7',
+    description: '프로젝트를 배포합니다',
+  },
   {
     name: 'waiting for review:검토 대기',
     color: 'fbca04',

--- a/src/github/issue/label.constants.ts
+++ b/src/github/issue/label.constants.ts
@@ -1,16 +1,16 @@
 import type { CreateLabelPayload } from '../client/github-api.client';
 
 export const COWORK_LABELS: CreateLabelPayload[] = [
-  { name: 'bug:버그', color: 'd73a4a', description: '버그 또는 오작동' },
-  { name: 'enhancement:개선작업', color: 'a2eeef', description: '기능 추가 또는 개선' },
-  { name: 'question:질문', color: 'd876e3', description: '질문 또는 문의' },
-  { name: 'default:기본', color: 'e4e669', description: '분류되지 않은 이슈' },
-  { name: 'blocked:차단됨', color: 'b60205', description: '진행이 차단된 이슈' },
-  { name: 'duplicate:중복', color: 'cfd3d7', description: '중복 이슈' },
-  { name: 'documentation:문서화', color: '0075ca', description: '문서 작성 또는 수정' },
-  { name: 'release:릴리즈', color: '5319e7', description: '릴리즈 관련 작업' },
-  { name: 'waiting-review:검토대기', color: 'fbca04', description: '검토 대기 상태' },
-  { name: 'first-contribution:첫기여', color: '7057ff', description: '첫 기여자에게 추천할 만한 작업' },
+  { name: 'bug:버그', color: 'd73a4a', description: '무언가 작동하지 않습니다' },
+  { name: 'enhancement:개선작업', color: 'a2eeef', description: '새 기능 또는 기존 코드 개선에 관한 내용입니다' },
+  { name: 'question:질문', color: 'd876e3', description: '질문 또는 문의사항이 있습니다' },
+  { name: 'default:기본', color: 'e4e669', description: '분류되지 않은 이슈입니다' },
+  { name: 'blocked:차단됨', color: 'b60205', description: '해당 작업은 다른 작업에 의해 차단되었습니다' },
+  { name: 'duplicate:중복', color: 'cfd3d7', description: '이 Issue 또는 Pull Request가 이미 존재합니다' },
+  { name: 'documentation:문서화', color: '0075ca', description: '문서에 대한 개선 또는 추가사항이 있습니다' },
+  { name: 'release:릴리즈', color: '5319e7', description: '프로젝트를 배포합니다' },
+  { name: 'waiting for review:검토 대기', color: 'fbca04', description: '확인을 대기하고 있습니다' },
+  { name: 'GFI:첫 기여 추천', color: '7057ff', description: '첫 기여로 훌륭한 Issue입니다' },
 ];
 
 export const COWORK_LABEL_PREFIX = '' as const;

--- a/src/github/issue/label.service.spec.ts
+++ b/src/github/issue/label.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { GithubApiClient } from '../client/github-api.client';
 import { CreateIssueDto } from '../dto/create-issue.dto';
 import { GithubClientError } from '../github.errors';
-import { COWORK_DEFAULT_LABELS } from './label.constants';
+import { COWORK_LABELS } from './label.constants';
 import { LabelService } from './label.service';
 
 describe('LabelService', () => {
@@ -15,14 +15,11 @@ describe('LabelService', () => {
     title: 'Issue title',
   };
 
-  const fullDefaultRepoLabels = COWORK_DEFAULT_LABELS.map(
-    (label) => label.name,
-  );
-  const partialDefaultRepoLabels = ['bug:버그'];
+  const allCoworkLabelNames = COWORK_LABELS.map((l) => l.name);
 
   beforeEach(async () => {
     apiClient = {
-      listLabels: jest.fn().mockResolvedValue(fullDefaultRepoLabels),
+      listLabels: jest.fn().mockResolvedValue(allCoworkLabelNames),
       createLabel: jest.fn().mockResolvedValue(undefined),
     };
 
@@ -36,151 +33,170 @@ describe('LabelService', () => {
     service = module.get<LabelService>(LabelService);
   });
 
-  describe('ensureUsableLabels', () => {
-    it('repo 라벨이 있으면 새 라벨을 생성하지 않는다', async () => {
-      await service.ensureUsableLabels('token', dto);
-      expect(apiClient.createLabel).not.toHaveBeenCalled();
-    });
+  // ─── resolveLabels ────────────────────────────────────────────────────────
 
-    it('요청 labels가 repo에 없으면 생성하고 반환 목록에 포함한다', async () => {
-      const result = await service.ensureUsableLabels('token', {
-        ...dto,
-        labels: ['unknown-label'],
+  describe('resolveLabels', () => {
+    describe('키워드 기반 cowork: 라벨', () => {
+      it('bug 키워드 포함 시 bug:버그를 반환한다', () => {
+        const result = service.resolveLabels({
+          ...dto,
+          title: '로그인 500 에러',
+          body: '카카오 로그인 실패',
+        });
+        expect(result).toContain('bug:버그');
       });
 
-      expect(apiClient.createLabel).toHaveBeenCalledWith(
-        'token',
-        expect.any(Object),
-        expect.objectContaining({ name: 'unknown-label', color: 'ededed' }),
-      );
-      expect(result).toContain('unknown-label');
-    });
-
-    it('요청 labels가 repo에 이미 있으면 생성하지 않는다', async () => {
-      await service.ensureUsableLabels('token', {
-        ...dto,
-        labels: ['bug:버그'],
+      it('enhancement 키워드 포함 시 enhancement:개선작업을 반환한다', () => {
+        const result = service.resolveLabels({
+          ...dto,
+          title: '기능 추가 요청',
+        });
+        expect(result).toContain('enhancement:개선작업');
       });
+
+      it('question 키워드 포함 시 question:질문을 반환한다', () => {
+        const result = service.resolveLabels({
+          ...dto,
+          title: '어떻게 사용하나요?',
+        });
+        expect(result).toContain('question:질문');
+      });
+
+      it('이상 표현은 bug:버그로 분류한다', () => {
+        const result = service.resolveLabels({ ...dto, title: '로그인 쪽이 이상해요' });
+        expect(result).toContain('bug:버그');
+      });
+
+      it('bug 키워드가 enhancement보다 우선한다', () => {
+        const result = service.resolveLabels({
+          ...dto,
+          title: '기능 추가 요청인데 오류가 있음',
+        });
+        expect(result).toContain('bug:버그');
+        expect(result).not.toContain('enhancement:개선작업');
+      });
+    });
+
+    describe('cowork:default fallback', () => {
+      it('키워드가 없으면 default:기본을 반환한다', () => {
+        const result = service.resolveLabels(dto);
+        expect(result).toEqual(['default:기본']);
+      });
+
+      it('명시 라벨만 있고 cowork 라벨이 없으면 default:기본을 추가한다', () => {
+        const result = service.resolveLabels({ ...dto, labels: ['urgent'] });
+        expect(result).toContain('urgent');
+        expect(result).toContain('default:기본');
+      });
+    });
+
+    describe('명시 라벨 처리', () => {
+      it('cowork 명시 라벨은 default:기본을 추가하지 않는다', () => {
+        const result = service.resolveLabels({
+          ...dto,
+          labels: ['blocked:차단됨'],
+        });
+        expect(result).toContain('blocked:차단됨');
+        expect(result).not.toContain('default:기본');
+      });
+
+      it('명시 라벨과 키워드 결과를 병합한다', () => {
+        const result = service.resolveLabels({
+          ...dto,
+          title: '로그인 에러',
+          labels: ['urgent'],
+        });
+        expect(result).toContain('urgent');
+        expect(result).toContain('bug:버그');
+        expect(result).not.toContain('default:기본');
+      });
+
+      it('명시 라벨과 키워드가 동일한 cowork 라벨이면 중복 없이 1개만 반환한다', () => {
+        const result = service.resolveLabels({
+          ...dto,
+          title: '기능 추가',
+          labels: ['enhancement:개선작업'],
+        });
+        expect(result.filter((l) => l === 'enhancement:개선작업')).toHaveLength(1);
+      });
+
+      it('빈 문자열 명시 라벨은 무시한다', () => {
+        const result = service.resolveLabels({ ...dto, labels: ['', '  '] });
+        expect(result).toEqual(['default:기본']);
+      });
+    });
+  });
+
+  // ─── ensureLabelsExist ────────────────────────────────────────────────────
+
+  describe('ensureLabelsExist', () => {
+    it('모든 라벨이 레포에 있으면 createLabel을 호출하지 않는다', async () => {
+      await service.ensureLabelsExist('token', dto, ['bug:버그']);
       expect(apiClient.createLabel).not.toHaveBeenCalled();
     });
 
-    it('repo에 일부 기본 라벨만 있어도 누락된 기본 라벨을 생성한다', async () => {
-      apiClient.listLabels.mockResolvedValue(partialDefaultRepoLabels);
+    it('레포에 없는 cowork 라벨은 정의된 color/description으로 생성한다', async () => {
+      apiClient.listLabels.mockResolvedValue([]);
 
-      await service.ensureUsableLabels('token', dto);
+      await service.ensureLabelsExist('token', dto, ['bug:버그']);
 
       expect(apiClient.createLabel).toHaveBeenCalledWith(
         'token',
         expect.any(Object),
-        expect.objectContaining({ name: 'blocked:차단됨' }),
+        expect.objectContaining({ name: 'bug:버그', color: 'd73a4a' }),
       );
+    });
+
+    it('레포에 없는 커스텀 라벨은 color=ededed로 생성한다', async () => {
+      apiClient.listLabels.mockResolvedValue([]);
+
+      await service.ensureLabelsExist('token', dto, ['urgent']);
+
       expect(apiClient.createLabel).toHaveBeenCalledWith(
         'token',
         expect.any(Object),
-        expect.objectContaining({ name: 'enhancement:개선작업' }),
+        expect.objectContaining({ name: 'urgent', color: 'ededed' }),
       );
     });
 
-    it('모든 기본 라벨이 이미 있으면 기본 라벨을 추가 생성하지 않는다', async () => {
-      apiClient.listLabels.mockResolvedValue(fullDefaultRepoLabels);
-
-      await service.ensureUsableLabels('token', dto);
-
-      expect(apiClient.createLabel).not.toHaveBeenCalled();
+    it('라벨 목록이 비어 있으면 listLabels를 호출하지 않는다', async () => {
+      await service.ensureLabelsExist('token', dto, []);
+      expect(apiClient.listLabels).not.toHaveBeenCalled();
     });
 
-    it('라벨 생성 시 422 에러는 이미 존재하는 것으로 간주하고 스킵한다', async () => {
+    it('422 에러는 스킵하고 계속 진행한다', async () => {
       apiClient.listLabels.mockResolvedValue([]);
       apiClient.createLabel.mockRejectedValue(
         new GithubClientError('already exists', 422),
       );
 
       await expect(
-        service.ensureUsableLabels('token', dto),
+        service.ensureLabelsExist('token', dto, ['bug:버그']),
       ).resolves.not.toThrow();
     });
 
-    it('라벨 생성 시 403 에러는 권한 없음으로 간주하고 스킵한다', async () => {
+    it('403 에러는 스킵하고 계속 진행한다', async () => {
       apiClient.listLabels.mockResolvedValue([]);
       apiClient.createLabel.mockRejectedValue(
         new GithubClientError('forbidden', 403),
       );
 
       await expect(
-        service.ensureUsableLabels('token', dto),
+        service.ensureLabelsExist('token', dto, ['bug:버그']),
       ).resolves.not.toThrow();
     });
 
-    it('요청 labels 생성 시 403 에러로 스킵되면 반환 목록에 포함하지 않는다', async () => {
-      apiClient.createLabel.mockRejectedValue(
-        new GithubClientError('forbidden', 403),
+    it('여러 라벨 중 일부만 없으면 없는 것만 생성한다', async () => {
+      apiClient.listLabels.mockResolvedValue(['bug:버그']);
+
+      await service.ensureLabelsExist('token', dto, ['bug:버그', 'default:기본']);
+
+      expect(apiClient.createLabel).toHaveBeenCalledTimes(1);
+      expect(apiClient.createLabel).toHaveBeenCalledWith(
+        'token',
+        expect.any(Object),
+        expect.objectContaining({ name: 'default:기본' }),
       );
-
-      const result = await service.ensureUsableLabels('token', {
-        ...dto,
-        labels: ['unknown-label'],
-      });
-
-      expect(result).not.toContain('unknown-label');
-    });
-  });
-
-  describe('resolveLabels', () => {
-    it('요청 labels가 있고 repo에 존재하면 해당 labels를 반환한다', () => {
-      const result = service.resolveLabels(
-        { ...dto, labels: ['bug:버그'] },
-        fullDefaultRepoLabels,
-      );
-      expect(result).toEqual(['bug:버그']);
-    });
-
-    it('요청 labels가 repo에 없으면 키워드 기반으로 추론한다', () => {
-      const result = service.resolveLabels(
-        { ...dto, title: '로그인 500 에러', labels: ['nonexistent'] },
-        fullDefaultRepoLabels,
-      );
-      expect(result).toEqual(['bug:버그']);
-    });
-
-    it('bug 키워드 포함 시 bug 라벨을 반환한다', () => {
-      const result = service.resolveLabels(
-        { ...dto, title: '로그인 500 에러', body: '카카오 로그인 실패' },
-        fullDefaultRepoLabels,
-      );
-      expect(result).toEqual(['bug:버그']);
-    });
-
-    it('애매한 이상 표현은 bug 라벨로 분류한다', () => {
-      const result = service.resolveLabels(
-        { ...dto, title: '로그인 쪽이 이상해요' },
-        fullDefaultRepoLabels,
-      );
-      expect(result).toEqual(['bug:버그']);
-    });
-
-    it('enhancement 키워드 포함 시 enhancement 라벨을 반환한다', () => {
-      const result = service.resolveLabels(
-        { ...dto, title: '기능 추가 요청' },
-        fullDefaultRepoLabels,
-      );
-      expect(result).toEqual(['enhancement:개선작업']);
-    });
-
-    it('repo 라벨명이 prefix 형태면 해당 라벨명으로 매칭한다', () => {
-      const result = service.resolveLabels({ ...dto, title: '기능 개선' }, [
-        'enhancement:개선작업',
-      ]);
-      expect(result).toEqual(['enhancement:개선작업']);
-    });
-
-    it('키워드가 없으면 fallback 라벨을 반환한다', () => {
-      const result = service.resolveLabels(dto, fullDefaultRepoLabels);
-      expect(result).toEqual(['help wanted:도움 필요']);
-    });
-
-    it('repo에 매칭 라벨이 없으면 빈 배열을 반환한다', () => {
-      const result = service.resolveLabels(dto, ['release:릴리즈']);
-      expect(result).toEqual([]);
     });
   });
 });

--- a/src/github/issue/label.service.spec.ts
+++ b/src/github/issue/label.service.spec.ts
@@ -78,26 +78,26 @@ describe('LabelService', () => {
     });
 
     describe('cowork:default fallback', () => {
-      it('키워드가 없으면 default:기본을 반환한다', () => {
+      it('키워드가 없으면 help wanted:도움 필요을 반환한다', () => {
         const result = service.resolveLabels(dto);
-        expect(result).toEqual(['default:기본']);
+        expect(result).toEqual(['help wanted:도움 필요']);
       });
 
-      it('명시 라벨만 있고 cowork 라벨이 없으면 default:기본을 추가한다', () => {
+      it('명시 라벨만 있고 cowork 라벨이 없으면 help wanted:도움 필요을 추가한다', () => {
         const result = service.resolveLabels({ ...dto, labels: ['urgent'] });
         expect(result).toContain('urgent');
-        expect(result).toContain('default:기본');
+        expect(result).toContain('help wanted:도움 필요');
       });
     });
 
     describe('명시 라벨 처리', () => {
-      it('cowork 명시 라벨은 default:기본을 추가하지 않는다', () => {
+      it('cowork 명시 라벨은 help wanted:도움 필요을 추가하지 않는다', () => {
         const result = service.resolveLabels({
           ...dto,
           labels: ['blocked:차단됨'],
         });
         expect(result).toContain('blocked:차단됨');
-        expect(result).not.toContain('default:기본');
+        expect(result).not.toContain('help wanted:도움 필요');
       });
 
       it('명시 라벨과 키워드 결과를 병합한다', () => {
@@ -108,7 +108,7 @@ describe('LabelService', () => {
         });
         expect(result).toContain('urgent');
         expect(result).toContain('bug:버그');
-        expect(result).not.toContain('default:기본');
+        expect(result).not.toContain('help wanted:도움 필요');
       });
 
       it('명시 라벨과 키워드가 동일한 cowork 라벨이면 중복 없이 1개만 반환한다', () => {
@@ -122,7 +122,7 @@ describe('LabelService', () => {
 
       it('빈 문자열 명시 라벨은 무시한다', () => {
         const result = service.resolveLabels({ ...dto, labels: ['', '  '] });
-        expect(result).toEqual(['default:기본']);
+        expect(result).toEqual(['help wanted:도움 필요']);
       });
     });
   });
@@ -189,13 +189,13 @@ describe('LabelService', () => {
     it('여러 라벨 중 일부만 없으면 없는 것만 생성한다', async () => {
       apiClient.listLabels.mockResolvedValue(['bug:버그']);
 
-      await service.ensureLabelsExist('token', dto, ['bug:버그', 'default:기본']);
+      await service.ensureLabelsExist('token', dto, ['bug:버그', 'help wanted:도움 필요']);
 
       expect(apiClient.createLabel).toHaveBeenCalledTimes(1);
       expect(apiClient.createLabel).toHaveBeenCalledWith(
         'token',
         expect.any(Object),
-        expect.objectContaining({ name: 'default:기본' }),
+        expect.objectContaining({ name: 'help wanted:도움 필요' }),
       );
     });
   });

--- a/src/github/issue/label.service.spec.ts
+++ b/src/github/issue/label.service.spec.ts
@@ -63,7 +63,10 @@ describe('LabelService', () => {
       });
 
       it('이상 표현은 bug:버그로 분류한다', () => {
-        const result = service.resolveLabels({ ...dto, title: '로그인 쪽이 이상해요' });
+        const result = service.resolveLabels({
+          ...dto,
+          title: '로그인 쪽이 이상해요',
+        });
         expect(result).toContain('bug:버그');
       });
 
@@ -117,7 +120,9 @@ describe('LabelService', () => {
           title: '기능 추가',
           labels: ['enhancement:개선작업'],
         });
-        expect(result.filter((l) => l === 'enhancement:개선작업')).toHaveLength(1);
+        expect(result.filter((l) => l === 'enhancement:개선작업')).toHaveLength(
+          1,
+        );
       });
 
       it('빈 문자열 명시 라벨은 무시한다', () => {
@@ -189,7 +194,10 @@ describe('LabelService', () => {
     it('여러 라벨 중 일부만 없으면 없는 것만 생성한다', async () => {
       apiClient.listLabels.mockResolvedValue(['bug:버그']);
 
-      await service.ensureLabelsExist('token', dto, ['bug:버그', 'help wanted:도움 필요']);
+      await service.ensureLabelsExist('token', dto, [
+        'bug:버그',
+        'help wanted:도움 필요',
+      ]);
 
       expect(apiClient.createLabel).toHaveBeenCalledTimes(1);
       expect(apiClient.createLabel).toHaveBeenCalledWith(

--- a/src/github/issue/label.service.ts
+++ b/src/github/issue/label.service.ts
@@ -16,7 +16,9 @@ import {
   QUESTION_LABEL,
 } from './label.constants';
 
-const COWORK_LABEL_NAMES = new Set(COWORK_LABELS.map((l) => l.name.toLowerCase()));
+const COWORK_LABEL_NAMES = new Set(
+  COWORK_LABELS.map((l) => l.name.toLowerCase()),
+);
 
 @Injectable()
 export class LabelService {
@@ -37,7 +39,9 @@ export class LabelService {
       ...(keywordLabel ? [keywordLabel] : []),
     ]);
 
-    const hasCowork = merged.some((l) => COWORK_LABEL_NAMES.has(l.toLowerCase()));
+    const hasCowork = merged.some((l) =>
+      COWORK_LABEL_NAMES.has(l.toLowerCase()),
+    );
     if (!hasCowork) {
       merged.push(COWORK_FALLBACK_LABEL);
     }

--- a/src/github/issue/label.service.ts
+++ b/src/github/issue/label.service.ts
@@ -7,14 +7,16 @@ import { CreateIssueDto } from '../dto/create-issue.dto';
 import { GithubClientError } from '../github.errors';
 import {
   BUG_KEYWORDS,
-  BUG_LABEL_CANDIDATES,
-  COWORK_DEFAULT_LABELS,
+  BUG_LABEL,
+  COWORK_FALLBACK_LABEL,
+  COWORK_LABELS,
   ENHANCEMENT_KEYWORDS,
-  ENHANCEMENT_LABEL_CANDIDATES,
-  FALLBACK_LABEL_CANDIDATES,
+  ENHANCEMENT_LABEL,
   QUESTION_KEYWORDS,
-  QUESTION_LABEL_CANDIDATES,
+  QUESTION_LABEL,
 } from './label.constants';
+
+const COWORK_LABEL_NAMES = new Set(COWORK_LABELS.map((l) => l.name.toLowerCase()));
 
 @Injectable()
 export class LabelService {
@@ -22,96 +24,51 @@ export class LabelService {
 
   constructor(private readonly apiClient: GithubApiClient) {}
 
-  async ensureUsableLabels(
-    token: string,
-    dto: CreateIssueDto,
-  ): Promise<string[]> {
-    const repoLabels = await this.apiClient.listLabels(token, dto);
-    const requestedLabels = dto.labels ?? [];
-
-    const createdDefaults = await this.createMissingLabels(
-      token,
-      dto,
-      COWORK_DEFAULT_LABELS,
-      repoLabels,
-    );
-
-    const handledRequested = await this.createRequestedLabels(
-      token,
-      dto,
-      requestedLabels,
-      [...repoLabels, ...createdDefaults],
-    );
-    return this.uniqueLabels([
-      ...repoLabels,
-      ...createdDefaults,
-      ...handledRequested,
-    ]);
-  }
-
-  resolveLabels(dto: CreateIssueDto, repoLabels: string[]): string[] {
-    if (dto.labels && dto.labels.length > 0) {
-      const matched = dto.labels.filter((label) =>
-        this.hasRepoLabel(repoLabels, label),
-      );
-      if (matched.length > 0) return matched;
-    }
+  resolveLabels(dto: CreateIssueDto): string[] {
+    const explicit = dto.labels
+      ? this.uniqueLabels(dto.labels.filter((l) => l.trim().length > 0))
+      : [];
 
     const text = `${dto.title} ${dto.body ?? ''}`.toLowerCase();
-    if (this.includesAny(text, BUG_KEYWORDS)) {
-      return this.matchRepoLabels(repoLabels, BUG_LABEL_CANDIDATES);
+    const keywordLabel = this.detectCoworkLabelName(text);
+
+    const merged = this.uniqueLabels([
+      ...explicit,
+      ...(keywordLabel ? [keywordLabel] : []),
+    ]);
+
+    const hasCowork = merged.some((l) => COWORK_LABEL_NAMES.has(l.toLowerCase()));
+    if (!hasCowork) {
+      merged.push(COWORK_FALLBACK_LABEL);
     }
-    if (this.includesAny(text, ENHANCEMENT_KEYWORDS)) {
-      return this.matchRepoLabels(repoLabels, ENHANCEMENT_LABEL_CANDIDATES);
-    }
-    if (this.includesAny(text, QUESTION_KEYWORDS)) {
-      return this.matchRepoLabels(repoLabels, QUESTION_LABEL_CANDIDATES);
-    }
-    return this.matchRepoLabels(repoLabels, FALLBACK_LABEL_CANDIDATES);
+
+    return merged;
   }
 
-  private async createRequestedLabels(
+  async ensureLabelsExist(
     token: string,
     dto: CreateIssueDto,
-    requestedLabels: string[],
-    existingLabels: string[],
-  ): Promise<string[]> {
-    const alreadyExisting = this.uniqueLabels(requestedLabels).filter((label) =>
-      this.hasRepoLabel(existingLabels, label),
-    );
+    labels: string[],
+  ): Promise<void> {
+    if (labels.length === 0) return;
 
-    const labelsToCreate = this.uniqueLabels(requestedLabels)
-      .filter((label) => label.trim().length > 0)
-      .filter((label) => !this.hasRepoLabel(existingLabels, label))
-      .map((label) => this.createCustomLabel(label));
+    const repoLabels = await this.apiClient.listLabels(token, dto);
 
-    const newlyCreated = await this.createMissingLabels(
-      token,
-      dto,
-      labelsToCreate,
-      existingLabels,
-    );
-    return this.uniqueLabels([...alreadyExisting, ...newlyCreated]);
-  }
+    for (const name of labels) {
+      if (this.hasRepoLabel(repoLabels, name)) continue;
 
-  private async createMissingLabels(
-    token: string,
-    dto: CreateIssueDto,
-    labels: CreateLabelPayload[],
-    existingLabels: string[],
-  ): Promise<string[]> {
-    const created: string[] = [];
-    for (const label of labels) {
-      if (this.hasRepoLabel(existingLabels, label.name)) continue;
+      const coworkDef = COWORK_LABELS.find(
+        (l) => l.name.toLowerCase() === name.toLowerCase(),
+      );
+      const payload = coworkDef ?? this.createCustomLabel(name);
 
       try {
-        await this.apiClient.createLabel(token, dto, label);
+        await this.apiClient.createLabel(token, dto, payload);
         this.logger.log('Repository label created', {
           owner: dto.owner,
           repo: dto.repo,
-          label: label.name,
+          label: name,
         });
-        created.push(label.name);
       } catch (error) {
         if (
           error instanceof GithubClientError &&
@@ -119,45 +76,24 @@ export class LabelService {
         ) {
           this.logger.log(
             `Repository label creation skipped (status: ${error.statusCode})`,
-            {
-              owner: dto.owner,
-              repo: dto.repo,
-              label: label.name,
-            },
+            { owner: dto.owner, repo: dto.repo, label: name },
           );
           continue;
         }
         throw error;
       }
     }
-    return created;
+  }
+
+  private detectCoworkLabelName(text: string): string | null {
+    if (this.includesAny(text, BUG_KEYWORDS)) return BUG_LABEL;
+    if (this.includesAny(text, ENHANCEMENT_KEYWORDS)) return ENHANCEMENT_LABEL;
+    if (this.includesAny(text, QUESTION_KEYWORDS)) return QUESTION_LABEL;
+    return null;
   }
 
   private includesAny(text: string, keywords: readonly string[]): boolean {
     return keywords.some((keyword) => text.includes(keyword));
-  }
-
-  private matchRepoLabels(
-    repoLabels: string[],
-    candidates: readonly string[],
-  ): string[] {
-    const normalized = repoLabels.map((label) => ({
-      label,
-      lower: label.toLowerCase(),
-    }));
-
-    for (const candidate of candidates) {
-      const lowerCandidate = candidate.toLowerCase();
-      const exact = normalized.find(({ lower }) => lower === lowerCandidate);
-      if (exact) return [exact.label];
-
-      const prefix = normalized.find(({ lower }) =>
-        lower.startsWith(`${lowerCandidate}:`),
-      );
-      if (prefix) return [prefix.label];
-    }
-
-    return [];
   }
 
   private hasRepoLabel(repoLabels: string[], label: string): boolean {

--- a/src/github/kafka/event/issue-result.event.ts
+++ b/src/github/kafka/event/issue-result.event.ts
@@ -1,0 +1,8 @@
+export interface IssueResultEvent {
+  channelId: number;
+  teamId: number;
+  success: boolean;
+  issueUrl?: string;
+  issueNumber?: number;
+  error?: string;
+}

--- a/src/github/kafka/issue-result.producer.ts
+++ b/src/github/kafka/issue-result.producer.ts
@@ -1,0 +1,38 @@
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { Kafka, Producer } from 'kafkajs';
+import { AppConfigService } from '../../config/app-config.service';
+import { IssueResultEvent } from './event/issue-result.event';
+
+@Injectable()
+export class IssueResultProducer implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(IssueResultProducer.name);
+  private producer!: Producer;
+
+  constructor(private readonly config: AppConfigService) {}
+
+  async onModuleInit() {
+    const kafka = new Kafka({
+      clientId: 'cowork-github',
+      brokers: this.config.kafkaBrokers,
+    });
+    this.producer = kafka.producer();
+    await this.producer.connect();
+    this.logger.log('Kafka result producer connected');
+  }
+
+  async onModuleDestroy() {
+    await this.producer.disconnect();
+  }
+
+  async send(event: IssueResultEvent): Promise<void> {
+    await this.producer.send({
+      topic: 'github.issue.result',
+      messages: [
+        {
+          key: event.channelId.toString(),
+          value: JSON.stringify(event),
+        },
+      ],
+    });
+  }
+}

--- a/src/github/kafka/issue-result.producer.ts
+++ b/src/github/kafka/issue-result.producer.ts
@@ -1,4 +1,9 @@
-import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
 import { Kafka, Producer } from 'kafkajs';
 import { AppConfigService } from '../../config/app-config.service';
 import { IssueResultEvent } from './event/issue-result.event';

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -3,6 +3,7 @@ import { INestApplication, ValidationPipe } from '@nestjs/common';
 import request from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from '../src/app.module';
+import { IssueResultProducer } from '../src/github/kafka/issue-result.producer';
 import { applyTestEnv, restoreTestEnv } from './support/test-env';
 
 describe('AppController (e2e)', () => {
@@ -14,7 +15,10 @@ describe('AppController (e2e)', () => {
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
-    }).compile();
+    })
+      .overrideProvider(IssueResultProducer)
+      .useValue({ send: jest.fn() })
+      .compile();
 
     app = moduleFixture.createNestApplication();
     app.useGlobalPipes(new ValidationPipe({ whitelist: true }));


### PR DESCRIPTION
## 개요

이슈 자동 라벨링 체계를 `cowork:` prefix 형식에서 레포 기존 형식(`bug:버그`, `enhancement:개선작업` 등)으로 통일하였습니다. 또한 키워드 미매칭 시 fallback 라벨을 `help wanted:도움 필요`로 변경하고, 이슈 생성 결과를 Kafka로 발행하는 `IssueResultProducer`를 추가하였습니다.

## 본문

**라벨 네이밍 통일**

기존 `cowork:bug`, `cowork:enhancement`, `cowork:question`, `cowork:default` 형식을 레포에서 사용 중인 `bug:버그`, `enhancement:개선작업`, `question:질문` 형식으로 변경하였습니다. 각 라벨의 description도 레포 기존 문구와 동일하게 정비하였습니다.

**Fallback 라벨 변경**

이슈 제목·본문 키워드가 어느 분류에도 해당하지 않을 때 자동으로 붙이는 fallback 라벨을 `default:기본`에서 `help wanted:도움 필요`로 변경하였습니다.

**IssueResultProducer 추가**

이슈 생성 결과(`issueUrl`, `issueNumber`, `success`, `error`)를 `github.issue.result` 토픽으로 발행하는 `IssueResultProducer`를 추가하였습니다. `channelId`와 `teamId`를 기반으로 이벤트 키를 설정하며, `GithubController`에서 이슈 생성 후 결과 이벤트를 전송하도록 연결하였습니다.

**동작 요건**

- 레포에 라벨이 없으면 이슈 생성 전 자동 생성
- 키워드 기반 자동 분류 (`bug:버그` / `enhancement:개선작업` / `question:질문`)
- 키워드 미매칭 시 `help wanted:도움 필요` 자동 부착
- 기존 이슈에는 부족한 라벨만 추가 (중복 없음)
- 기존 레포 라벨 삭제 없음
