### PR TITLE
[github] GithubApiClient에 인증 위임으로 token 파라미터 전달 제거

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/axios": "^4.0.1",
-        "@nestjs/common": "^11.0.1",
+        "@nestjs/common": "^11.1.19",
         "@nestjs/config": "^4.0.4",
         "@nestjs/core": "^11.0.1",
         "@nestjs/microservices": "^11.1.19",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@nestjs/axios": "^4.0.1",
-    "@nestjs/common": "^11.0.1",
+    "@nestjs/common": "^11.1.19",
     "@nestjs/config": "^4.0.4",
     "@nestjs/core": "^11.0.1",
     "@nestjs/microservices": "^11.1.19",

--- a/src/github/client/github-api.client.spec.ts
+++ b/src/github/client/github-api.client.spec.ts
@@ -4,12 +4,14 @@ import { AxiosError } from 'axios';
 import type { AxiosResponse } from 'axios';
 import { of, throwError } from 'rxjs';
 import { GithubApiClient } from './github-api.client';
+import { GithubAuthService } from '../auth/github-auth.service';
 import { GithubClientError } from '../github.errors';
 import { CreateIssueDto } from '../dto/create-issue.dto';
 
 describe('GithubApiClient', () => {
   let client: GithubApiClient;
   let httpService: { get: jest.Mock; post: jest.Mock };
+  let authService: { getInstallationToken: jest.Mock };
 
   const dto: CreateIssueDto = {
     owner: 'my-org',
@@ -20,11 +22,15 @@ describe('GithubApiClient', () => {
 
   beforeEach(async () => {
     httpService = { get: jest.fn(), post: jest.fn() };
+    authService = {
+      getInstallationToken: jest.fn().mockResolvedValue('my-token'),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GithubApiClient,
         { provide: HttpService, useValue: httpService },
+        { provide: GithubAuthService, useValue: authService },
       ],
     }).compile();
 
@@ -41,7 +47,7 @@ describe('GithubApiClient', () => {
       }),
     );
 
-    const result = await client.createIssue('my-token', dto);
+    const result = await client.createIssue(dto);
 
     expect(result).toEqual({
       number: 42,
@@ -67,7 +73,7 @@ describe('GithubApiClient', () => {
     httpService.post.mockReturnValue(throwError(() => axiosError));
 
     const error = await client
-      .createIssue('my-token', dto)
+      .createIssue(dto)
       .catch((e: unknown) => e as GithubClientError);
 
     expect(error).toBeInstanceOf(GithubClientError);
@@ -84,7 +90,7 @@ describe('GithubApiClient', () => {
     httpService.post.mockReturnValue(throwError(() => axiosError));
 
     const error = await client
-      .createIssue('my-token', dto)
+      .createIssue(dto)
       .catch((e: unknown) => e as GithubClientError);
 
     expect(error).toBeInstanceOf(GithubClientError);
@@ -97,7 +103,7 @@ describe('GithubApiClient', () => {
     httpService.post.mockReturnValue(throwError(() => axiosError));
 
     const error = await client
-      .createIssue('my-token', dto)
+      .createIssue(dto)
       .catch((e: unknown) => e as AxiosError);
 
     expect(error).toBeInstanceOf(AxiosError);
@@ -109,7 +115,7 @@ describe('GithubApiClient', () => {
     httpService.post.mockReturnValue(throwError(() => networkError));
 
     const error = await client
-      .createIssue('my-token', dto)
+      .createIssue(dto)
       .catch((e: unknown) => e as AxiosError);
 
     expect(error).toBeInstanceOf(AxiosError);
@@ -132,7 +138,7 @@ describe('GithubApiClient', () => {
       }),
     );
 
-    const result = await client.searchOpenIssuesByTitle('my-token', dto);
+    const result = await client.searchOpenIssuesByTitle(dto);
 
     expect(result).toEqual([
       {
@@ -158,7 +164,7 @@ describe('GithubApiClient', () => {
   it('기존 이슈에 라벨을 추가한다', async () => {
     httpService.post.mockReturnValue(of({ data: {} }));
 
-    await client.addLabelsToIssue('my-token', dto, 7, ['bug']);
+    await client.addLabelsToIssue(dto, 7, ['bug']);
 
     expect(httpService.post).toHaveBeenCalledWith(
       'https://api.github.com/repos/my-org/my-repo/issues/7/labels',
@@ -178,7 +184,7 @@ describe('GithubApiClient', () => {
       }),
     );
 
-    const result = await client.listLabels('my-token', dto);
+    const result = await client.listLabels(dto);
 
     expect(result).toEqual(['bug', 'enhancement:개선작업']);
     expect(httpService.get).toHaveBeenCalledWith(
@@ -194,7 +200,7 @@ describe('GithubApiClient', () => {
   it('repo에 라벨을 생성한다', async () => {
     httpService.post.mockReturnValue(of({ data: {} }));
 
-    await client.createLabel('my-token', dto, {
+    await client.createLabel(dto, {
       name: 'bug:버그',
       color: 'd73a4a',
       description: '버그 또는 오작동',
@@ -224,7 +230,7 @@ describe('GithubApiClient', () => {
     httpService.get.mockReturnValue(throwError(() => axiosError));
 
     const error = await client
-      .searchOpenIssuesByTitle('my-token', dto)
+      .searchOpenIssuesByTitle(dto)
       .catch((e: unknown) => e as GithubClientError);
 
     expect(error).toBeInstanceOf(GithubClientError);
@@ -237,7 +243,7 @@ describe('GithubApiClient', () => {
     httpService.post.mockReturnValue(throwError(() => axiosError));
 
     const error = await client
-      .addLabelsToIssue('my-token', dto, 7, ['bug'])
+      .addLabelsToIssue(dto, 7, ['bug'])
       .catch((e: unknown) => e as AxiosError);
 
     expect(error).toBeInstanceOf(AxiosError);

--- a/src/github/client/github-api.client.ts
+++ b/src/github/client/github-api.client.ts
@@ -118,7 +118,10 @@ export class GithubApiClient {
     }
   }
 
-  async createLabel(dto: CreateIssueDto, label: CreateLabelPayload): Promise<void> {
+  async createLabel(
+    dto: CreateIssueDto,
+    label: CreateLabelPayload,
+  ): Promise<void> {
     const token = await this.authService.getInstallationToken(dto.owner);
     try {
       await firstValueFrom(

--- a/src/github/client/github-api.client.ts
+++ b/src/github/client/github-api.client.ts
@@ -2,6 +2,7 @@ import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
 import { AxiosError } from 'axios';
 import { firstValueFrom } from 'rxjs';
+import { GithubAuthService } from '../auth/github-auth.service';
 import { GITHUB_API, GITHUB_HEADERS } from '../constants';
 import { CreateIssueDto } from '../dto/create-issue.dto';
 import { GithubClientError } from '../github.errors';
@@ -30,9 +31,13 @@ export interface CreateLabelPayload {
 
 @Injectable()
 export class GithubApiClient {
-  constructor(private readonly httpService: HttpService) {}
+  constructor(
+    private readonly httpService: HttpService,
+    private readonly authService: GithubAuthService,
+  ) {}
 
-  async createIssue(token: string, dto: CreateIssueDto): Promise<CreatedIssue> {
+  async createIssue(dto: CreateIssueDto): Promise<CreatedIssue> {
+    const token = await this.authService.getInstallationToken(dto.owner);
     try {
       const { data } = await firstValueFrom(
         this.httpService.post<CreatedIssue>(
@@ -52,10 +57,8 @@ export class GithubApiClient {
     }
   }
 
-  async searchOpenIssuesByTitle(
-    token: string,
-    dto: CreateIssueDto,
-  ): Promise<SearchedIssue[]> {
+  async searchOpenIssuesByTitle(dto: CreateIssueDto): Promise<SearchedIssue[]> {
+    const token = await this.authService.getInstallationToken(dto.owner);
     try {
       const escapedTitle = dto.title
         .replace(/\\/g, '\\\\')
@@ -82,11 +85,11 @@ export class GithubApiClient {
   }
 
   async addLabelsToIssue(
-    token: string,
     dto: CreateIssueDto,
     issueNumber: number,
     labels: string[],
   ): Promise<void> {
+    const token = await this.authService.getInstallationToken(dto.owner);
     try {
       await firstValueFrom(
         this.httpService.post(
@@ -100,7 +103,8 @@ export class GithubApiClient {
     }
   }
 
-  async listLabels(token: string, dto: CreateIssueDto): Promise<string[]> {
+  async listLabels(dto: CreateIssueDto): Promise<string[]> {
+    const token = await this.authService.getInstallationToken(dto.owner);
     try {
       const { data } = await firstValueFrom(
         this.httpService.get<GithubLabel[]>(
@@ -114,11 +118,8 @@ export class GithubApiClient {
     }
   }
 
-  async createLabel(
-    token: string,
-    dto: CreateIssueDto,
-    label: CreateLabelPayload,
-  ): Promise<void> {
+  async createLabel(dto: CreateIssueDto, label: CreateLabelPayload): Promise<void> {
+    const token = await this.authService.getInstallationToken(dto.owner);
     try {
       await firstValueFrom(
         this.httpService.post(

--- a/src/github/issue/issue.service.spec.ts
+++ b/src/github/issue/issue.service.spec.ts
@@ -1,6 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppConfigService } from '../../config/app-config.service';
-import { GithubAuthService } from '../auth/github-auth.service';
 import { GithubApiClient } from '../client/github-api.client';
 import { CreateIssueDto } from '../dto/create-issue.dto';
 import { GithubClientError } from '../github.errors';
@@ -9,7 +8,6 @@ import { LabelService } from './label.service';
 
 describe('IssueService', () => {
   let service: IssueService;
-  let authService: { getInstallationToken: jest.Mock };
   let apiClient: {
     createIssue: jest.Mock;
     searchOpenIssuesByTitle: jest.Mock;
@@ -38,9 +36,6 @@ describe('IssueService', () => {
   const RESOLVED_LABELS = ['help wanted:도움 필요'];
 
   beforeEach(async () => {
-    authService = {
-      getInstallationToken: jest.fn().mockResolvedValue('token'),
-    };
     apiClient = {
       createIssue: jest.fn().mockResolvedValue(createdIssue),
       searchOpenIssuesByTitle: jest.fn().mockResolvedValue([]),
@@ -55,7 +50,6 @@ describe('IssueService', () => {
       providers: [
         IssueService,
         { provide: AppConfigService, useValue: { githubIssueMaxRetries: 3 } },
-        { provide: GithubAuthService, useValue: authService },
         { provide: GithubApiClient, useValue: apiClient },
         { provide: LabelService, useValue: labelService },
       ],
@@ -68,18 +62,13 @@ describe('IssueService', () => {
   it('정상 처리 시 라벨을 해석하고 이슈를 생성한 뒤 issueUrl과 issueNumber를 반환한다', async () => {
     const result = await service.createIssue(dto);
 
-    expect(authService.getInstallationToken).toHaveBeenCalledWith(dto.owner);
     expect(labelService.resolveLabels).toHaveBeenCalledWith(dto);
     expect(labelService.ensureLabelsExist).toHaveBeenCalledWith(
-      'token',
       dto,
       RESOLVED_LABELS,
     );
-    expect(apiClient.searchOpenIssuesByTitle).toHaveBeenCalledWith(
-      'token',
-      dto,
-    );
-    expect(apiClient.createIssue).toHaveBeenCalledWith('token', {
+    expect(apiClient.searchOpenIssuesByTitle).toHaveBeenCalledWith(dto);
+    expect(apiClient.createIssue).toHaveBeenCalledWith({
       ...dto,
       labels: RESOLVED_LABELS,
     });
@@ -94,7 +83,7 @@ describe('IssueService', () => {
 
     await service.createIssue(dto);
 
-    expect(apiClient.createIssue).toHaveBeenCalledWith('token', {
+    expect(apiClient.createIssue).toHaveBeenCalledWith({
       ...dto,
       labels: ['help wanted:도움 필요'],
     });
@@ -106,7 +95,6 @@ describe('IssueService', () => {
     const result = await service.createIssue(dto);
 
     expect(apiClient.addLabelsToIssue).toHaveBeenCalledWith(
-      'token',
       dto,
       7,
       RESOLVED_LABELS,
@@ -129,7 +117,7 @@ describe('IssueService', () => {
 
     await service.createIssue(dto);
 
-    expect(apiClient.addLabelsToIssue).toHaveBeenCalledWith('token', dto, 7, [
+    expect(apiClient.addLabelsToIssue).toHaveBeenCalledWith(dto, 7, [
       'bug:버그',
     ]);
     expect(apiClient.createIssue).not.toHaveBeenCalled();

--- a/src/github/issue/issue.service.ts
+++ b/src/github/issue/issue.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { AppConfigService } from '../../config/app-config.service';
 import { GithubApiClient } from '../client/github-api.client';
-import { GithubAuthService } from '../auth/github-auth.service';
 import { CreateIssueDto } from '../dto/create-issue.dto';
 import { GithubClientError } from '../github.errors';
 import { LabelService } from './label.service';
@@ -12,7 +11,6 @@ export class IssueService {
 
   constructor(
     private readonly config: AppConfigService,
-    private readonly authService: GithubAuthService,
     private readonly apiClient: GithubApiClient,
     private readonly labelService: LabelService,
   ) {}
@@ -24,14 +22,10 @@ export class IssueService {
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
-        const token = await this.authService.getInstallationToken(dto.owner);
         const labels = this.labelService.resolveLabels(dto);
-        await this.labelService.ensureLabelsExist(token, dto, labels);
+        await this.labelService.ensureLabelsExist(dto, labels);
 
-        const existingIssues = await this.apiClient.searchOpenIssuesByTitle(
-          token,
-          dto,
-        );
+        const existingIssues = await this.apiClient.searchOpenIssuesByTitle(dto);
         const existingIssue = existingIssues.find(
           (issue) => issue.title === dto.title,
         );
@@ -47,7 +41,6 @@ export class IssueService {
 
           if (newLabels.length > 0) {
             await this.apiClient.addLabelsToIssue(
-              token,
               dto,
               existingIssue.number,
               newLabels,
@@ -71,7 +64,7 @@ export class IssueService {
           };
         }
 
-        const result = await this.apiClient.createIssue(token, {
+        const result = await this.apiClient.createIssue({
           ...dto,
           labels,
         });

--- a/src/github/issue/issue.service.ts
+++ b/src/github/issue/issue.service.ts
@@ -25,7 +25,8 @@ export class IssueService {
         const labels = this.labelService.resolveLabels(dto);
         await this.labelService.ensureLabelsExist(dto, labels);
 
-        const existingIssues = await this.apiClient.searchOpenIssuesByTitle(dto);
+        const existingIssues =
+          await this.apiClient.searchOpenIssuesByTitle(dto);
         const existingIssue = existingIssues.find(
           (issue) => issue.title === dto.title,
         );

--- a/src/github/issue/label.service.spec.ts
+++ b/src/github/issue/label.service.spec.ts
@@ -136,17 +136,16 @@ describe('LabelService', () => {
 
   describe('ensureLabelsExist', () => {
     it('모든 라벨이 레포에 있으면 createLabel을 호출하지 않는다', async () => {
-      await service.ensureLabelsExist('token', dto, ['bug:버그']);
+      await service.ensureLabelsExist(dto, ['bug:버그']);
       expect(apiClient.createLabel).not.toHaveBeenCalled();
     });
 
     it('레포에 없는 cowork 라벨은 정의된 color/description으로 생성한다', async () => {
       apiClient.listLabels.mockResolvedValue([]);
 
-      await service.ensureLabelsExist('token', dto, ['bug:버그']);
+      await service.ensureLabelsExist(dto, ['bug:버그']);
 
       expect(apiClient.createLabel).toHaveBeenCalledWith(
-        'token',
         expect.any(Object),
         expect.objectContaining({ name: 'bug:버그', color: 'd73a4a' }),
       );
@@ -155,17 +154,16 @@ describe('LabelService', () => {
     it('레포에 없는 커스텀 라벨은 color=ededed로 생성한다', async () => {
       apiClient.listLabels.mockResolvedValue([]);
 
-      await service.ensureLabelsExist('token', dto, ['urgent']);
+      await service.ensureLabelsExist(dto, ['urgent']);
 
       expect(apiClient.createLabel).toHaveBeenCalledWith(
-        'token',
         expect.any(Object),
         expect.objectContaining({ name: 'urgent', color: 'ededed' }),
       );
     });
 
     it('라벨 목록이 비어 있으면 listLabels를 호출하지 않는다', async () => {
-      await service.ensureLabelsExist('token', dto, []);
+      await service.ensureLabelsExist(dto, []);
       expect(apiClient.listLabels).not.toHaveBeenCalled();
     });
 
@@ -176,7 +174,7 @@ describe('LabelService', () => {
       );
 
       await expect(
-        service.ensureLabelsExist('token', dto, ['bug:버그']),
+        service.ensureLabelsExist(dto, ['bug:버그']),
       ).resolves.not.toThrow();
     });
 
@@ -187,21 +185,20 @@ describe('LabelService', () => {
       );
 
       await expect(
-        service.ensureLabelsExist('token', dto, ['bug:버그']),
+        service.ensureLabelsExist(dto, ['bug:버그']),
       ).resolves.not.toThrow();
     });
 
     it('여러 라벨 중 일부만 없으면 없는 것만 생성한다', async () => {
       apiClient.listLabels.mockResolvedValue(['bug:버그']);
 
-      await service.ensureLabelsExist('token', dto, [
+      await service.ensureLabelsExist(dto, [
         'bug:버그',
         'help wanted:도움 필요',
       ]);
 
       expect(apiClient.createLabel).toHaveBeenCalledTimes(1);
       expect(apiClient.createLabel).toHaveBeenCalledWith(
-        'token',
         expect.any(Object),
         expect.objectContaining({ name: 'help wanted:도움 필요' }),
       );

--- a/src/github/issue/label.service.ts
+++ b/src/github/issue/label.service.ts
@@ -50,13 +50,12 @@ export class LabelService {
   }
 
   async ensureLabelsExist(
-    token: string,
     dto: CreateIssueDto,
     labels: string[],
   ): Promise<void> {
     if (labels.length === 0) return;
 
-    const repoLabels = await this.apiClient.listLabels(token, dto);
+    const repoLabels = await this.apiClient.listLabels(dto);
 
     for (const name of labels) {
       if (this.hasRepoLabel(repoLabels, name)) continue;
@@ -67,7 +66,7 @@ export class LabelService {
       const payload = coworkDef ?? this.createCustomLabel(name);
 
       try {
-        await this.apiClient.createLabel(token, dto, payload);
+        await this.apiClient.createLabel(dto, payload);
         this.logger.log('Repository label created', {
           owner: dto.owner,
           repo: dto.repo,


### PR DESCRIPTION
## 개요

`GithubApiClient`가 `GithubAuthService`를 직접 주입받아 내부에서 인증 토큰을 처리하도록 변경하였습니다. 기존에 `IssueService`가 토큰을 발급한 뒤 `LabelService`와 `GithubApiClient`에 파라미터로 전달하던 구조를 제거하였습니다.

## 본문

### 변경 전 의존성 구조

```
IssueService
├── GithubAuthService  (토큰 발급)
├── GithubApiClient    (token 파라미터로 수신)
└── LabelService
      └── GithubApiClient  (token 파라미터로 수신)
```

`IssueService`가 토큰을 발급한 뒤 `LabelService.ensureLabelsExist(token, dto, labels)`와 `GithubApiClient`의 모든 메서드에 `token`을 첫 번째 인자로 전달하였습니다. 인증 관심사가 서비스 경계를 넘나드는 구조였습니다.

### 변경 후 의존성 구조

```
IssueService
├── GithubApiClient    (인증 없음)
└── LabelService
      └── GithubApiClient  (인증 없음)

GithubApiClient
└── GithubAuthService  (내부에서 자체 해결)
```

### 주요 변경 사항

- `GithubApiClient`: `GithubAuthService`를 생성자 주입, 모든 public 메서드(`createIssue`, `searchOpenIssuesByTitle`, `addLabelsToIssue`, `listLabels`, `createLabel`)에서 `token` 파라미터를 제거하고 내부에서 `dto.owner`로 토큰을 조회하도록 변경하였습니다.
- `LabelService`: `ensureLabelsExist(token, dto, labels)` → `ensureLabelsExist(dto, labels)`로 변경하였습니다.
- `IssueService`: `GithubAuthService` 의존성 및 토큰 발급/전달 코드를 제거하였습니다.
- 각 서비스의 단위 테스트를 변경된 인터페이스에 맞게 업데이트하였습니다.

토큰 캐싱은 `GithubAuthService` 내부의 Redis 및 인메모리 캐시로 처리되므로 API 호출마다 새 토큰이 발급되지 않습니다.
