### PR TITLE
[ci/cd] Cloudtype 배포 스텝 제거

### DIFF
--- a/.github/workflows/cowork-prod-cd.yml
+++ b/.github/workflows/cowork-prod-cd.yml
@@ -64,14 +64,6 @@ jobs:
             --title "${{ steps.version.outputs.version }}" \
             --notes $'## 수정내역\n\n- main 브랜치 배포 기준 자동 릴리스'
 
-      - name: Deploy to Cloudtype
-        run: |
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
-            -H "Content-Type: application/json" \
-            "${{ secrets.CLOUDTYPE_DEPLOY_HOOK }}")
-          echo "Cloudtype response: $STATUS"
-          [[ "$STATUS" =~ ^2 ]] || (echo "Cloudtype deploy trigger failed (HTTP $STATUS)" && exit 1)
-
       - name: Notify Discord
         if: always()
         uses: sarisia/actions-status-discord@v1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,5 +80,5 @@ INTERNAL_API_KEY=                       # cowork 백엔드 ↔ 이 서비스 간
 
 - `cowork-stage-ci.yml`: install, lint, build, test on PR/push targeting `develop`
 - `cowork-prod-ci.yml`: install, lint, build, test on PR/push targeting `main`
-- `cowork-prod-cd.yml`: creates a date-based tag, GitHub Release, and triggers Cloudtype deployment after `main` push
+- `cowork-prod-cd.yml`: creates a date-based tag and GitHub Release after `main` push (deployment to the school server is manual, not automated by this workflow)
 - `cowork-pr-cleanup.yml`: removes waiting labels from merged PRs


### PR DESCRIPTION
Cloudtype 배포를 하지 않기로 결정하여 cowork-prod-cd.yml의 'Deploy to Cloudtype' 스텝을 제거하였습니다. 배포는 학교 서버에서 수동으로 진행합니다.