### PR TITLE
[ci/cd] 학교 서버 도커 배포 스크립트 추가

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 학교 서버에서 SSH 접속 후 이 스크립트를 실행해 배포합니다.
+# 사용 전 아래 값을 서버 환경에 맞게 채워주세요. (docker ps / docker network ls로 확인)
+NETWORK_NAME="${NETWORK_NAME:-cowork-net}"
+KAFKA_CONTAINER="${KAFKA_CONTAINER:-}"
+REDIS_CONTAINER="${REDIS_CONTAINER:-}"
+APP_NAME="cowork-github-app"
+APP_PORT="${APP_PORT:-3000}"
+ENV_FILE="${ENV_FILE:-.env}"
+
+if [[ -z "$KAFKA_CONTAINER" || -z "$REDIS_CONTAINER" ]]; then
+  echo "KAFKA_CONTAINER / REDIS_CONTAINER 환경변수를 설정해주세요. 예:"
+  echo "  KAFKA_CONTAINER=kafka REDIS_CONTAINER=redis ./scripts/deploy.sh"
+  exit 1
+fi
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "$ENV_FILE 파일이 없습니다. 운영용 .env를 먼저 서버에 준비해주세요."
+  exit 1
+fi
+
+echo "==> 최신 main 가져오기"
+git checkout main
+git pull origin main
+
+echo "==> 공유 네트워크 준비"
+docker network inspect "$NETWORK_NAME" >/dev/null 2>&1 || docker network create "$NETWORK_NAME"
+docker network connect "$NETWORK_NAME" "$KAFKA_CONTAINER" 2>/dev/null || true
+docker network connect "$NETWORK_NAME" "$REDIS_CONTAINER" 2>/dev/null || true
+
+echo "==> 이미지 빌드"
+docker build -t "$APP_NAME:latest" .
+
+echo "==> 기존 컨테이너 정리"
+docker stop "$APP_NAME" 2>/dev/null || true
+docker rm "$APP_NAME" 2>/dev/null || true
+
+echo "==> 컨테이너 기동"
+docker run -d \
+  --name "$APP_NAME" \
+  --network "$NETWORK_NAME" \
+  --env-file "$ENV_FILE" \
+  -p "$APP_PORT:3000" \
+  --restart unless-stopped \
+  "$APP_NAME:latest"
+
+echo "==> 헬스체크 (5초 대기 후 확인)"
+sleep 5
+curl -fsS "http://localhost:$APP_PORT/health" && echo " - OK" || echo " - 실패, docker logs $APP_NAME 확인 필요"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -46,6 +46,19 @@ docker run -d \
   --restart unless-stopped \
   "$APP_NAME:latest"
 
-echo "==> 헬스체크 (5초 대기 후 확인)"
-sleep 5
-curl -fsS "http://localhost:$APP_PORT/health" && echo " - OK" || echo " - 실패, docker logs $APP_NAME 확인 필요"
+echo "==> 헬스체크 시작 (최대 15초 대기)"
+success=false
+for i in {1..15}; do
+  if curl -fsS "http://localhost:$APP_PORT/health" >/dev/null 2>&1; then
+    success=true
+    break
+  fi
+  sleep 1
+done
+
+if [[ "$success" == "true" ]]; then
+  echo " - OK"
+else
+  echo " - 실패, docker logs $APP_NAME 확인 필요"
+  exit 1
+fi


### PR DESCRIPTION
## 개요

Cloudtype 대신 학교 서버에 SSH로 접속해 Docker로 직접 배포할 때 사용할 배포 스크립트(`scripts/deploy.sh`)를 추가하였습니다.

## 본문

### 배경

직전 PR(#49)에서 `cowork-prod-cd.yml`의 Cloudtype 배포 트리거를 제거하였습니다. 이제 배포는 학교 서버에 SSH로 접속하여 `git pull` 후 Docker로 직접 띄우는 방식으로 진행합니다. 매번 수동으로 같은 명령을 입력하지 않도록 재사용 가능한 스크립트로 정리하였습니다.

### 스크립트 동작 (`scripts/deploy.sh`)

1. `main` 브랜치 체크아웃 및 `git pull`
2. 공유 Docker 네트워크 준비 (없으면 생성)
3. 기존에 떠 있는 Kafka/Redis 컨테이너를 해당 네트워크에 연결 (이미 연결되어 있으면 무시)
4. `Dockerfile` 기준 이미지 빌드
5. 기존 `cowork-github-app` 컨테이너 정리 후 재기동 (`--restart unless-stopped`)
6. `/health` 엔드포인트로 기동 확인

### 사용법

```bash
KAFKA_CONTAINER=<kafka 컨테이너명> REDIS_CONTAINER=<redis 컨테이너명> ./scripts/deploy.sh
```

- `NETWORK_NAME`, `APP_PORT`, `ENV_FILE`은 필요 시 환경변수로 override 가능 (기본값: `cowork-net`, `3000`, `.env`)
- 서버에 운영용 `.env` 파일이 미리 준비되어 있어야 하며, `KAFKA_BROKERS`/`REDIS_HOST`는 컨테이너 이름 기준으로 설정해야 함 (예: `KAFKA_BROKERS=kafka:9092`)

### 범위 제외

- 운영용 `.env` 파일 자체는 저장소에 포함하지 않음 (보안상 서버에 별도 관리)
- Kafka/Redis 컨테이너를 직접 띄우는 작업은 이 스크립트 범위 밖 (이미 서버에 존재한다고 가정)
