### PR TITLE
[ci/cd] 배포 스크립트 호스트 네트워크 구조에 맞게 단순화

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,19 +2,11 @@
 set -euo pipefail
 
 # 학교 서버에서 SSH 접속 후 이 스크립트를 실행해 배포합니다.
-# 사용 전 아래 값을 서버 환경에 맞게 채워주세요. (docker ps / docker network ls로 확인)
-NETWORK_NAME="${NETWORK_NAME:-cowork-net}"
-KAFKA_CONTAINER="${KAFKA_CONTAINER:-}"
-REDIS_CONTAINER="${REDIS_CONTAINER:-}"
+# Kafka/Redis는 이 서버가 아닌 별도 서버(10.0.0.93)에서 동작하므로,
+# 컨테이너 네트워크 연결 없이 .env의 KAFKA_BROKERS/REDIS_HOST로 접속합니다.
 APP_NAME="cowork-github-app"
 APP_PORT="${APP_PORT:-3000}"
 ENV_FILE="${ENV_FILE:-.env}"
-
-if [[ -z "$KAFKA_CONTAINER" || -z "$REDIS_CONTAINER" ]]; then
-  echo "KAFKA_CONTAINER / REDIS_CONTAINER 환경변수를 설정해주세요. 예:"
-  echo "  KAFKA_CONTAINER=kafka REDIS_CONTAINER=redis ./scripts/deploy.sh"
-  exit 1
-fi
 
 if [[ ! -f "$ENV_FILE" ]]; then
   echo "$ENV_FILE 파일이 없습니다. 운영용 .env를 먼저 서버에 준비해주세요."
@@ -24,11 +16,6 @@ fi
 echo "==> 최신 main 가져오기"
 git checkout main
 git pull origin main
-
-echo "==> 공유 네트워크 준비"
-docker network inspect "$NETWORK_NAME" >/dev/null 2>&1 || docker network create "$NETWORK_NAME"
-docker network connect "$NETWORK_NAME" "$KAFKA_CONTAINER" 2>/dev/null || true
-docker network connect "$NETWORK_NAME" "$REDIS_CONTAINER" 2>/dev/null || true
 
 echo "==> 이미지 빌드"
 docker build -t "$APP_NAME:latest" .
@@ -40,7 +27,6 @@ docker rm "$APP_NAME" 2>/dev/null || true
 echo "==> 컨테이너 기동"
 docker run -d \
   --name "$APP_NAME" \
-  --network "$NETWORK_NAME" \
   --env-file "$ENV_FILE" \
   -p "$APP_PORT:3000" \
   --restart unless-stopped \


### PR DESCRIPTION
## 개요

학교 서버의 실제 인프라 구성을 확인한 결과 Kafka/Redis가 별도 컨테이너 네트워크 연결 없이 호스트에 게시된 포트로 바로 접근 가능하여, 불필요한 도커 네트워크 연결 로직을 제거하였습니다.

## 본문

### 배경

`scripts/deploy.sh`를 처음 작성할 때는 Kafka/Redis가 별도 컨테이너로 떠 있고 이 앱 컨테이너와 같은 도커 네트워크로 묶어야 한다고 가정하였습니다. 실제 서버에서 `docker ps`로 확인한 결과:

- `cowork-kafka`, `cowork-redis`가 이미 같은 호스트에서 동작 중이며, 호스트 포트로 게시(publish)되어 있음
- Kafka는 내부 포트 `9092`가 아닌 호스트 게시 포트 `9094`로 외부에서 접근해야 함
- Redis는 `6379`로 정상 게시되어 있음

즉, 컨테이너 이름 기반 네트워크 연결이 아니라 호스트 IP(`10.0.0.93`) + 게시된 포트로 직접 접속하면 되는 구조였습니다.

### 변경 사항

- `NETWORK_NAME`, `KAFKA_CONTAINER`, `REDIS_CONTAINER` 변수 및 관련 분기 제거
- `docker network create` / `docker network connect` 로직 제거
- `docker run` 시 `--network` 옵션 제거 (기본 bridge 네트워크로 충분)

### 운영 `.env` 설정 값 (참고)

```env
KAFKA_BROKERS=10.0.0.93:9094
REDIS_HOST=10.0.0.93
REDIS_PORT=6379
```

### 테스트

- `bash -n scripts/deploy.sh`로 문법 검증
- `npm run build` 정상 통과 확인 (앱 코드 변경 없음)
